### PR TITLE
chore: add Docker development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Build artifacts
+target/
+debug/
+
+# Git
+.git/
+.gitignore
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Reference repos (large, not needed in container)
+reference/
+
+# Documentation (not needed for build)
+*.md
+LICENSE
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Mutation testing output
+**/mutants.out*/
+
+# Claude config
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# ============================================================
+# anytomd-rs Development Container
+# ============================================================
+# Provides a reproducible Linux build/test environment.
+# Usage: see docker-compose.yml or the "Docker Development" section in CLAUDE.md.
+
+ARG RUST_VERSION=1.83.0
+
+# ------------------------------------------------------------
+# Stage 1: chef — install cargo-chef for dependency caching
+# ------------------------------------------------------------
+FROM rust:${RUST_VERSION}-bookworm AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+# ------------------------------------------------------------
+# Stage 2: planner — generate a dependency recipe
+# ------------------------------------------------------------
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ------------------------------------------------------------
+# Stage 3: builder — build dependencies (cached), then the project
+# ------------------------------------------------------------
+FROM chef AS builder
+
+# Install clippy and rustfmt components
+RUN rustup component add clippy rustfmt
+
+# Build dependencies first (cached as long as recipe.json doesn't change)
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --recipe-path recipe.json
+RUN cargo chef cook --recipe-path recipe.json --release
+
+# Copy the full source tree
+COPY . .
+
+# Default command: run the full verification loop
+CMD ["sh", "-c", "cargo fmt --check && cargo clippy -- -D warnings && cargo test && cargo build --release"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,88 @@
+# ============================================================
+# anytomd-rs Docker Compose — Development Tasks
+# ============================================================
+# Run common development tasks in a reproducible Linux container.
+#
+# Usage:
+#   docker compose run --rm test       # Run all tests
+#   docker compose run --rm lint       # clippy + fmt check
+#   docker compose run --rm verify     # Full verification loop
+#   docker compose run --rm build      # Debug build only
+#   docker compose run --rm release    # Release build
+#   docker compose run --rm shell      # Interactive shell
+#
+# First run will be slow (dependency compilation). Subsequent runs
+# reuse the cached layers and cargo registry/target via volumes.
+
+services:
+  # Base service — not run directly, extended by others
+  base:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      # Mount source so edits on host are reflected immediately
+      - .:/app
+      # Persist cargo registry and git db across runs
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+      # Persist target directory for incremental compilation
+      - cargo-target:/app/target
+    working_dir: /app
+
+  # ---- Task services ----
+
+  build:
+    extends: base
+    command: cargo build
+
+  release:
+    extends: base
+    command: cargo build --release
+
+  test:
+    extends: base
+    command: cargo test
+
+  test-lib:
+    extends: base
+    command: cargo test --lib
+
+  test-integration:
+    extends: base
+    command: ["cargo", "test", "--test", "*"]
+
+  lint:
+    extends: base
+    command: >
+      sh -c "cargo fmt --check && cargo clippy -- -D warnings"
+
+  fmt:
+    extends: base
+    command: cargo fmt
+
+  verify:
+    extends: base
+    command: >
+      sh -c "
+        echo '=== Step 1/4: Format check ===' &&
+        cargo fmt --check &&
+        echo '=== Step 2/4: Clippy ===' &&
+        cargo clippy -- -D warnings &&
+        echo '=== Step 3/4: Tests ===' &&
+        cargo test &&
+        echo '=== Step 4/4: Release build ===' &&
+        cargo build --release &&
+        echo '=== All checks passed ==='
+      "
+
+  shell:
+    extends: base
+    command: /bin/bash
+    stdin_open: true
+    tty: true
+
+volumes:
+  cargo-registry:
+  cargo-git:
+  cargo-target:


### PR DESCRIPTION
## Summary

- Add `Dockerfile` with multi-stage build using `cargo-chef` for dependency caching
- Add `docker-compose.yml` with task-oriented services (`verify`, `test`, `lint`, `build`, `release`, `fmt`, `shell`, etc.)
- Add `.dockerignore` to exclude unnecessary files from Docker build context
- Add "Docker Development Environment" section to `CLAUDE.md` with usage guide, service reference table, and guidelines

## Key Design Decisions

- **cargo-chef** for dependency layer caching — rebuilds after source-only changes skip dependency compilation
- **Named volumes** (`cargo-registry`, `cargo-git`, `cargo-target`) persist compiled artifacts across `docker compose run` invocations for fast incremental builds
- **Bind-mount source directory** so host edits are instantly reflected in the container
- **Base service pattern** in docker-compose — all task services extend `base`, avoiding duplication
- Docker is documented as an **optional** development tool — native `cargo` remains the primary workflow

## Available Services

| Service | Description |
|---------|-------------|
| `verify` | Full verification loop (fmt + clippy + test + release) |
| `test` | Run all tests |
| `test-lib` | Unit tests only |
| `test-integration` | Integration tests only |
| `lint` | clippy + fmt check |
| `fmt` | Auto-format with rustfmt |
| `build` | Debug build |
| `release` | Release build |
| `shell` | Interactive bash shell |

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] `docker compose run --rm verify` runs all 4 verification steps (requires Cargo.toml to exist)
- [ ] `docker compose run --rm shell` drops into interactive bash
- [ ] `docker compose down -v` cleans up volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)