### PR TITLE
feat: implement plain text converter

### DIFF
--- a/src/converter/plain_text.rs
+++ b/src/converter/plain_text.rs
@@ -1,1 +1,148 @@
+use crate::converter::{ConversionOptions, ConversionResult, Converter};
+use crate::error::ConvertError;
+
 pub struct PlainTextConverter;
+
+impl Converter for PlainTextConverter {
+    fn supported_extensions(&self) -> &[&str] {
+        &[
+            "txt", "text", "log", "md", "markdown", "rst", "ini", "cfg", "conf", "toml", "yaml",
+            "yml",
+        ]
+    }
+
+    fn convert(
+        &self,
+        data: &[u8],
+        _options: &ConversionOptions,
+    ) -> Result<ConversionResult, ConvertError> {
+        let text = String::from_utf8(data.to_vec())?;
+
+        // Strip UTF-8 BOM if present
+        let text = text.strip_prefix('\u{FEFF}').unwrap_or(&text);
+
+        Ok(ConversionResult {
+            markdown: text.to_string(),
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plain_text_simple_passthrough() {
+        let converter = PlainTextConverter;
+        let input = b"Hello, world!";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "Hello, world!");
+    }
+
+    #[test]
+    fn test_plain_text_empty_input() {
+        let converter = PlainTextConverter;
+        let result = converter
+            .convert(b"", &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "");
+    }
+
+    #[test]
+    fn test_plain_text_multiline() {
+        let converter = PlainTextConverter;
+        let input = b"Line 1\nLine 2\nLine 3\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "Line 1\nLine 2\nLine 3\n");
+    }
+
+    #[test]
+    fn test_plain_text_utf8_bom_stripped() {
+        let converter = PlainTextConverter;
+        let mut input = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM
+        input.extend_from_slice(b"BOM content");
+        let result = converter
+            .convert(&input, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "BOM content");
+    }
+
+    #[test]
+    fn test_plain_text_unicode_cjk() {
+        let converter = PlainTextConverter;
+        let input = "한국어 中文 日本語".as_bytes();
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "한국어 中文 日本語");
+    }
+
+    #[test]
+    fn test_plain_text_emoji() {
+        let converter = PlainTextConverter;
+        let input = "Hello 🌍🚀✨ World".as_bytes();
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "Hello 🌍🚀✨ World");
+    }
+
+    #[test]
+    fn test_plain_text_invalid_utf8_returns_error() {
+        let converter = PlainTextConverter;
+        let input = vec![0xFF, 0xFE, 0x00];
+        let result = converter.convert(&input, &ConversionOptions::default());
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ConvertError::Utf8Error(_)));
+    }
+
+    #[test]
+    fn test_plain_text_supported_extensions() {
+        let converter = PlainTextConverter;
+        assert!(converter.supported_extensions().contains(&"txt"));
+        assert!(converter.supported_extensions().contains(&"md"));
+        assert!(converter.supported_extensions().contains(&"log"));
+        assert!(converter.supported_extensions().contains(&"yaml"));
+        assert!(!converter.supported_extensions().contains(&"docx"));
+    }
+
+    #[test]
+    fn test_plain_text_can_convert() {
+        let converter = PlainTextConverter;
+        assert!(converter.can_convert("txt", &[]));
+        assert!(converter.can_convert("md", &[]));
+        assert!(!converter.can_convert("docx", &[]));
+    }
+
+    #[test]
+    fn test_plain_text_no_title_extracted() {
+        let converter = PlainTextConverter;
+        let result = converter
+            .convert(b"Some text", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.title.is_none());
+    }
+
+    #[test]
+    fn test_plain_text_no_images_extracted() {
+        let converter = PlainTextConverter;
+        let result = converter
+            .convert(b"Some text", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.images.is_empty());
+    }
+
+    #[test]
+    fn test_plain_text_no_warnings() {
+        let converter = PlainTextConverter;
+        let result = converter
+            .convert(b"Some text", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.warnings.is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,14 +36,21 @@ pub fn convert_file(
 }
 
 /// Convert raw bytes to Markdown with an explicit format extension.
-///
-/// Currently returns `UnsupportedFormat` for all formats — individual converters
-/// will be wired in as they are implemented.
 pub fn convert_bytes(
-    _data: &[u8],
+    data: &[u8],
     extension: &str,
-    _options: &ConversionOptions,
+    options: &ConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
+    use converter::plain_text::PlainTextConverter;
+
+    let converters: Vec<Box<dyn Converter>> = vec![Box::new(PlainTextConverter)];
+
+    for conv in &converters {
+        if conv.can_convert(extension, data) {
+            return conv.convert(data, options);
+        }
+    }
+
     Err(ConvertError::UnsupportedFormat {
         extension: extension.to_string(),
     })

--- a/tests/fixtures/expected/sample.txt.md
+++ b/tests/fixtures/expected/sample.txt.md
@@ -1,0 +1,10 @@
+Hello, world!
+
+This is a sample plain text file for testing.
+
+It has multiple paragraphs and supports:
+- Unicode: 한국어 中文 日本語
+- Emoji: 🚀✨🌍
+- Special characters: é à ü ñ
+
+End of file.

--- a/tests/fixtures/sample.txt
+++ b/tests/fixtures/sample.txt
@@ -1,0 +1,10 @@
+Hello, world!
+
+This is a sample plain text file for testing.
+
+It has multiple paragraphs and supports:
+- Unicode: 한국어 中文 日本語
+- Emoji: 🚀✨🌍
+- Special characters: é à ü ñ
+
+End of file.

--- a/tests/test_plain_text.rs
+++ b/tests/test_plain_text.rs
@@ -1,0 +1,52 @@
+use anytomd::{convert_file, ConversionOptions};
+
+/// Normalize whitespace for golden test comparison:
+/// trim each line, collapse consecutive blank lines, strip trailing newline.
+fn normalize(s: &str) -> String {
+    let lines: Vec<&str> = s.lines().map(|l| l.trim_end()).collect();
+    let mut result = String::new();
+    let mut prev_blank = false;
+    for line in &lines {
+        let is_blank = line.is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+        prev_blank = is_blank;
+    }
+    result.trim_end().to_string()
+}
+
+/// Integration test: sample.txt end-to-end conversion via convert_file.
+#[test]
+fn test_plain_text_convert_file_sample() {
+    let result = convert_file("tests/fixtures/sample.txt", &ConversionOptions::default()).unwrap();
+    assert!(result.markdown.contains("Hello, world!"));
+    assert!(result.markdown.contains("한국어 中文 日本語"));
+    assert!(result.markdown.contains("🚀✨🌍"));
+}
+
+/// Golden test: compare normalized output against expected file.
+#[test]
+fn test_plain_text_golden_sample() {
+    let result = convert_file("tests/fixtures/sample.txt", &ConversionOptions::default()).unwrap();
+    let expected = include_str!("fixtures/expected/sample.txt.md");
+    assert_eq!(normalize(&result.markdown), normalize(expected));
+}
+
+/// Integration test: convert_file with a .md extension is detected as plain text.
+#[test]
+fn test_plain_text_md_extension_detected() {
+    // Use convert_bytes directly since we don't have a .md fixture file
+    let input = b"# Heading\n\nSome markdown content.";
+    let result = anytomd::convert_bytes(input, "md", &ConversionOptions::default()).unwrap();
+    assert_eq!(result.markdown, "# Heading\n\nSome markdown content.");
+}
+
+/// Integration test: unsupported format still returns error.
+#[test]
+fn test_unsupported_format_returns_error() {
+    let result = anytomd::convert_bytes(b"data", "xyz", &ConversionOptions::default());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

- Implement `PlainTextConverter` — the first converter with full `Converter` trait implementation
- Wire up `convert_bytes` to dispatch to registered converters (pattern used by all future converters)
- Add test fixture, golden test, and integration tests for plain text format

## Key changes

- **src/converter/plain_text.rs** — `PlainTextConverter` implementing `Converter` trait: UTF-8 passthrough with BOM stripping, supports 12 text-like extensions
- **src/lib.rs** — `convert_bytes` now dispatches to registered converters instead of always returning `UnsupportedFormat`
- **tests/test_plain_text.rs** — 4 integration tests (convert_file, golden test, .md extension detection, unsupported format error)
- **tests/fixtures/sample.txt** — Test fixture with multilingual Unicode and emoji
- **tests/fixtures/expected/sample.txt.md** — Golden file for normalized comparison

## Test coverage (16 new tests)

**Unit tests (12):**
- Simple passthrough, empty input, multiline preservation
- UTF-8 BOM stripping
- CJK Unicode (Korean/Chinese/Japanese) preservation
- Emoji preservation
- Invalid UTF-8 returns `Utf8Error`
- Supported extensions, can_convert
- No title/images/warnings on output

**Integration tests (4):**
- End-to-end `convert_file` with content assertions
- Golden test with normalized comparison
- `.md` extension detected as plain text
- Unsupported format still returns error

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — 38 tests pass (34 unit + 4 integration)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] `cargo build --release` — succeeds
- [ ] CI passes on ubuntu-latest, macos-latest, windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)