### PR TITLE
chore: rename package from anytomd-rs to anytomd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "anytomd-rs"
+name = "anytomd"
 version = "0.1.0"
 dependencies = [
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,11 @@
 [package]
-name = "anytomd-rs"
+name = "anytomd"
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"
 description = "Pure Rust library that converts various document formats into Markdown"
-repository = "https://github.com/yhkwon6/anytomd-rs"
-
-[lib]
-name = "anytomd"
-path = "src/lib.rs"
+repository = "https://github.com/developer0hye/anytomd-rs"
 
 [dependencies]
 zip = "2"


### PR DESCRIPTION
## Summary

- Rename crates.io package from `anytomd-rs` to `anytomd` for cleaner install: `cargo add anytomd`
- Remove redundant `[lib]` section (lib name defaults to package name)
- Fix repository URL to point to correct GitHub org

The crate has been published as `anytomd v0.1.0` on crates.io.

## Test plan

- [x] `cargo build` compiles
- [x] `cargo test` — 38 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] Published to crates.io as `anytomd v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)