### PR TITLE
feat: add CSV converter

### DIFF
--- a/src/converter/csv_conv.rs
+++ b/src/converter/csv_conv.rs
@@ -1,1 +1,212 @@
+use crate::converter::{ConversionOptions, ConversionResult, Converter};
+use crate::error::ConvertError;
+use crate::markdown::build_table;
+
 pub struct CsvConverter;
+
+impl Converter for CsvConverter {
+    fn supported_extensions(&self) -> &[&str] {
+        &["csv"]
+    }
+
+    fn convert(
+        &self,
+        data: &[u8],
+        _options: &ConversionOptions,
+    ) -> Result<ConversionResult, ConvertError> {
+        let text = String::from_utf8(data.to_vec())?;
+        let text = text.strip_prefix('\u{FEFF}').unwrap_or(&text);
+
+        let mut reader = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .flexible(true)
+            .from_reader(text.as_bytes());
+
+        let mut records = reader.records();
+
+        // First record becomes the header
+        let header_record = match records.next() {
+            Some(Ok(rec)) => rec,
+            Some(Err(e)) => {
+                return Err(ConvertError::MalformedDocument {
+                    reason: format!("failed to parse CSV header: {e}"),
+                });
+            }
+            None => {
+                return Ok(ConversionResult {
+                    markdown: String::new(),
+                    ..Default::default()
+                });
+            }
+        };
+
+        let headers: Vec<String> = header_record.iter().map(|s| s.to_string()).collect();
+
+        let mut rows: Vec<Vec<String>> = Vec::new();
+        for result in records {
+            match result {
+                Ok(record) => {
+                    let row: Vec<String> = record.iter().map(|s| s.to_string()).collect();
+                    rows.push(row);
+                }
+                Err(e) => {
+                    return Err(ConvertError::MalformedDocument {
+                        reason: format!("failed to parse CSV row: {e}"),
+                    });
+                }
+            }
+        }
+
+        let header_refs: Vec<&str> = headers.iter().map(|s| s.as_str()).collect();
+        let row_refs: Vec<Vec<&str>> = rows
+            .iter()
+            .map(|row| row.iter().map(|s| s.as_str()).collect())
+            .collect();
+        let markdown = build_table(&header_refs, &row_refs);
+
+        Ok(ConversionResult {
+            markdown,
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_csv_simple_table() {
+        let converter = CsvConverter;
+        let input = b"A,B,C\n1,2,3\n4,5,6\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("| A | B | C |"));
+        assert!(result.markdown.contains("|---|---|---|"));
+        assert!(result.markdown.contains("| 1 | 2 | 3 |"));
+        assert!(result.markdown.contains("| 4 | 5 | 6 |"));
+    }
+
+    #[test]
+    fn test_csv_single_row_header_only() {
+        let converter = CsvConverter;
+        let input = b"X,Y,Z\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("| X | Y | Z |"));
+        assert!(result.markdown.contains("|---|---|---|"));
+        let lines: Vec<&str> = result.markdown.lines().collect();
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn test_csv_single_column() {
+        let converter = CsvConverter;
+        let input = b"Name\nAlice\nBob\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("| Name |"));
+        assert!(result.markdown.contains("| Alice |"));
+        assert!(result.markdown.contains("| Bob |"));
+    }
+
+    #[test]
+    fn test_csv_empty_input() {
+        let converter = CsvConverter;
+        let result = converter
+            .convert(b"", &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "");
+    }
+
+    #[test]
+    fn test_csv_unicode_cjk() {
+        let converter = CsvConverter;
+        let input = "이름,나이\n홍길동,30\n田中,25\n".as_bytes();
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("홍길동"));
+        assert!(result.markdown.contains("田中"));
+        assert!(result.markdown.contains("이름"));
+    }
+
+    #[test]
+    fn test_csv_emoji() {
+        let converter = CsvConverter;
+        let input = "Symbol,Meaning\n🚀,Rocket\n✨,Sparkle\n".as_bytes();
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("🚀"));
+        assert!(result.markdown.contains("✨"));
+    }
+
+    #[test]
+    fn test_csv_quoted_fields() {
+        let converter = CsvConverter;
+        let input = b"Name,City\nAlice,\"New York\"\nBob,\"San Francisco\"\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("New York"));
+        assert!(result.markdown.contains("San Francisco"));
+    }
+
+    #[test]
+    fn test_csv_short_rows_padded() {
+        let converter = CsvConverter;
+        let input = b"A,B,C\n1\n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("| 1 |  |  |"));
+    }
+
+    #[test]
+    fn test_csv_whitespace_in_cells() {
+        let converter = CsvConverter;
+        let input = b"Key,Value\n hello , world \n";
+        let result = converter
+            .convert(input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains(" hello "));
+        assert!(result.markdown.contains(" world "));
+    }
+
+    #[test]
+    fn test_csv_supported_extensions() {
+        let converter = CsvConverter;
+        assert!(converter.supported_extensions().contains(&"csv"));
+        assert!(!converter.supported_extensions().contains(&"txt"));
+    }
+
+    #[test]
+    fn test_csv_can_convert() {
+        let converter = CsvConverter;
+        assert!(converter.can_convert("csv", &[]));
+        assert!(!converter.can_convert("json", &[]));
+    }
+
+    #[test]
+    fn test_csv_no_title_images_warnings() {
+        let converter = CsvConverter;
+        let result = converter
+            .convert(b"A\n1\n", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.title.is_none());
+        assert!(result.images.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_csv_invalid_utf8_returns_error() {
+        let converter = CsvConverter;
+        let input = vec![0xFF, 0xFE];
+        let result = converter.convert(&input, &ConversionOptions::default());
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,15 @@ pub fn convert_bytes(
     extension: &str,
     options: &ConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
+    use converter::csv_conv::CsvConverter;
     use converter::json_conv::JsonConverter;
     use converter::plain_text::PlainTextConverter;
 
-    let converters: Vec<Box<dyn Converter>> =
-        vec![Box::new(JsonConverter), Box::new(PlainTextConverter)];
+    let converters: Vec<Box<dyn Converter>> = vec![
+        Box::new(JsonConverter),
+        Box::new(CsvConverter),
+        Box::new(PlainTextConverter),
+    ];
 
     for conv in &converters {
         if conv.can_convert(extension, data) {

--- a/tests/fixtures/expected/sample.csv.md
+++ b/tests/fixtures/expected/sample.csv.md
@@ -1,0 +1,6 @@
+| Name | Age | City |
+|---|---|---|
+| Alice | 30 | Seoul |
+| Bob | 25 | 東京 |
+| Charlie | 35 | New York |
+| 다영 | 28 | 서울 |

--- a/tests/fixtures/sample.csv
+++ b/tests/fixtures/sample.csv
@@ -1,0 +1,5 @@
+Name,Age,City
+Alice,30,Seoul
+Bob,25,東京
+Charlie,35,"New York"
+다영,28,서울

--- a/tests/test_csv.rs
+++ b/tests/test_csv.rs
@@ -1,0 +1,48 @@
+use anytomd::{convert_file, ConversionOptions};
+
+/// Normalize whitespace for golden test comparison:
+/// trim each line, collapse consecutive blank lines, strip trailing newline.
+fn normalize(s: &str) -> String {
+    let lines: Vec<&str> = s.lines().map(|l| l.trim_end()).collect();
+    let mut result = String::new();
+    let mut prev_blank = false;
+    for line in &lines {
+        let is_blank = line.is_empty();
+        if is_blank && prev_blank {
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+        prev_blank = is_blank;
+    }
+    result.trim_end().to_string()
+}
+
+/// Integration test: sample.csv end-to-end conversion via convert_file.
+/// Fixture contains ASCII, CJK, quoted fields, and Korean names.
+#[test]
+fn test_csv_convert_file_sample() {
+    let result = convert_file("tests/fixtures/sample.csv", &ConversionOptions::default()).unwrap();
+    assert!(result.markdown.contains("Alice"));
+    assert!(result.markdown.contains("東京"));
+    assert!(result.markdown.contains("서울"));
+    assert!(result.markdown.contains("New York"));
+    assert!(result.markdown.contains("다영"));
+}
+
+/// Golden test: compare normalized output against expected file.
+#[test]
+fn test_csv_golden_sample() {
+    let result = convert_file("tests/fixtures/sample.csv", &ConversionOptions::default()).unwrap();
+    let expected = include_str!("fixtures/expected/sample.csv.md");
+    assert_eq!(normalize(&result.markdown), normalize(expected));
+}
+
+/// Integration test: convert_bytes with explicit "csv" extension.
+#[test]
+fn test_csv_convert_bytes_direct() {
+    let input = b"X,Y\n1,2\n";
+    let result = anytomd::convert_bytes(input, "csv", &ConversionOptions::default()).unwrap();
+    assert!(result.markdown.contains("| X | Y |"));
+    assert!(result.markdown.contains("| 1 | 2 |"));
+}


### PR DESCRIPTION
## Summary

- Implement `CsvConverter` that converts CSV files to pipe-delimited Markdown tables
- Uses the `csv` crate for parsing and the existing `build_table()` utility for output
- First row is treated as header; handles UTF-8 BOM stripping, quoted fields, flexible row lengths (short rows padded), CJK text, and emoji

## Key Changes

- **`src/converter/csv_conv.rs`**: New `CsvConverter` implementing the `Converter` trait with 13 unit tests
- **`src/lib.rs`**: Wire `CsvConverter` into `convert_bytes` dispatch (JSON → CSV → PlainText order)
- **`tests/test_csv.rs`**: 3 integration tests (content assertions, golden test, `convert_bytes` direct)
- **`tests/fixtures/sample.csv`**: Test fixture with ASCII, CJK, quoted fields, Korean names
- **`tests/fixtures/expected/sample.csv.md`**: Golden file for normalized comparison

## Test plan

- [x] 13 unit tests pass (simple table, header-only, single column, empty, CJK, emoji, quoted fields, short rows, whitespace, extensions, can_convert, metadata, invalid UTF-8)
- [x] 3 integration tests pass (convert_file content, golden test, convert_bytes)
- [x] All 70 tests pass (60 unit + 10 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)