### PR TITLE
feat: normalize XLSX error cells and DateTime formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ repository = "https://github.com/developer0hye/anytomd-rs"
 [dependencies]
 zip = "2"
 quick-xml = "0.37"
-calamine = "0.26"
+calamine = { version = "0.26", features = ["dates"] }
+chrono = { version = "0.4", default-features = false }
 csv = "1"
 serde_json = "1"
 ego-tree = "0.10"


### PR DESCRIPTION
## Summary

- Error cells (e.g. `#DIV/0!`, `#N/A`) now display error text instead of empty string, with `MalformedSegment` warning including cell location (e.g. `Sheet1!A2`)
- DateTime cells formatted as `YYYY-MM-DD` (date-only) or `YYYY-MM-DD HH:MM:SS` (with time component) using chrono via calamine's `dates` feature
- Add `col_letter()` helper for Excel-style column references (A, B, ..., Z, AA, AB, ...)

## Key changes

- `Cargo.toml`: Enable calamine `dates` feature, add `chrono` dependency (already transitive via calamine)
- `src/converter/xlsx.rs`: Modify `format_cell()` to accept `location` and `warnings` parameters; add `col_letter()` helper; handle `Data::Error` and `Data::DateTime` variants properly

## Test plan

- [x] `test_xlsx_format_cell_error_displays_text` — #DIV/0! displayed
- [x] `test_xlsx_format_cell_error_na` — #N/A displayed
- [x] `test_xlsx_format_cell_error_emits_warning` — MalformedSegment warning with location
- [x] `test_xlsx_format_cell_datetime_date_only` — 2024-01-15 format
- [x] `test_xlsx_format_cell_datetime_full` — 2024-01-15 12:00:00 format
- [x] `test_xlsx_format_cell_datetime_with_time` — 2024-01-15 14:30:15 format
- [x] `test_xlsx_format_cell_datetime_time_only` — time-only values
- [x] `test_col_letter_single` / `test_col_letter_multi` — column letter generation
- [x] All existing tests continue to pass (181 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)