### PR TITLE
docs: add LLM integration guidance with Gemini default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ anytomd-rs supports optional LLM-based image description via the `ImageDescriber
 **Default LLM provider: Google Gemini**
 
 - Use **Google Gemini** as the default LLM provider for built-in / example implementations
-- Default model: **`gemini-2.0-flash`**
+- Default model: **`gemini-3-flash-preview`**
 - When developing or updating any Gemini-related code (API calls, authentication, model parameters, request/response formats), **always consult the [official Gemini API documentation](https://ai.google.dev/gemini-api/docs)** for the latest specs — do NOT rely on cached knowledge or outdated examples
 - API keys are the caller's responsibility — the library never stores or manages credentials
 - The `ImageDescriber` trait is provider-agnostic: Gemini is the default, but any LLM backend can be used

--- a/PRD.md
+++ b/PRD.md
@@ -367,7 +367,7 @@ pub struct ConversionOptions {
 
 When building the built-in / example `ImageDescriber` implementation:
 - Use **Google Gemini** as the LLM provider
-- Default model: **`gemini-2.0-flash`**
+- Default model: **`gemini-3-flash-preview`**
 - Always refer to the [official Gemini API documentation](https://ai.google.dev/gemini-api/docs) for the latest API specs, authentication methods, and model availability before implementing or updating Gemini-related code
 
 ---


### PR DESCRIPTION
## Summary

- Add LLM-assisted image description design to PRD and development guidance to CLAUDE.md
- Establish Google Gemini as the default LLM provider with `gemini-2.0-flash` as the default model

## Key changes

### PRD.md
- **§1.5 Non-Goals**: Remove "LLM-dependent features" from non-goals (image description is now in-scope)
- **§4.9 (new)**: `ImageDescriber` trait design — trait-based injection, no HTTP calls in the library, provider-agnostic
- **§10 Comparison table**: Update LLM features row
- **§9 Milestones / Future**: Add `ImageDescriber` trait + Gemini example to backlog

### CLAUDE.md
- **LLM Integration — Gemini (new section)**: Default provider, default model, requirement to reference official Gemini API docs for all Gemini-related development

🤖 Generated with [Claude Code](https://claude.com/claude-code)