### PR TITLE
docs: add API key management guidance for GeminiDescriber

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,8 @@ anytomd-rs supports optional LLM-based image description via the `ImageDescriber
 - Use **Google Gemini** as the default LLM provider for built-in / example implementations
 - Default model: **`gemini-3-flash-preview`**
 - When developing or updating any Gemini-related code (API calls, authentication, model parameters, request/response formats), **always consult the [official Gemini API documentation](https://ai.google.dev/gemini-api/docs)** for the latest specs — do NOT rely on cached knowledge or outdated examples
-- API keys are the caller's responsibility — the library never stores or manages credentials
 - The `ImageDescriber` trait is provider-agnostic: Gemini is the default, but any LLM backend can be used
+- **API key management:** The `ImageDescriber` trait has no key concept. The built-in `GeminiDescriber` accepts a key via struct field (`new(api_key)`) and also provides an env-var fallback (`from_env()` reads `GEMINI_API_KEY`). Never hardcode, log, or persist API keys in library code.
 
 ---
 

--- a/PRD.md
+++ b/PRD.md
@@ -370,6 +370,24 @@ When building the built-in / example `ImageDescriber` implementation:
 - Default model: **`gemini-3-flash-preview`**
 - Always refer to the [official Gemini API documentation](https://ai.google.dev/gemini-api/docs) for the latest API specs, authentication methods, and model availability before implementing or updating Gemini-related code
 
+**API key management:**
+
+The `ImageDescriber` trait has no concept of API keys — credential handling is entirely the implementor's responsibility. The built-in `GeminiDescriber` example should follow this pattern:
+
+```rust
+impl GeminiDescriber {
+    /// Create with an explicit API key.
+    pub fn new(api_key: String) -> Self { ... }
+
+    /// Create from the `GEMINI_API_KEY` environment variable.
+    pub fn from_env() -> Result<Self, ConvertError> { ... }
+}
+```
+
+- **Struct field** (`new`): The primary way — caller passes the key directly. Suitable for libraries and applications that manage secrets themselves.
+- **Environment variable fallback** (`from_env`): Reads `GEMINI_API_KEY` from the environment. Convenient for CLI usage and examples.
+- The library must **never** hardcode, log, or persist API keys.
+
 ---
 
 ## 5. Dependencies


### PR DESCRIPTION
## Summary

- Add API key management pattern for the built-in `GeminiDescriber` implementation
- Two ways to provide keys: struct field (`new(api_key)`) or env var fallback (`from_env()` reads `GEMINI_API_KEY`)
- Library must never hardcode, log, or persist API keys

## Key changes

- **PRD §4.9**: Add "API key management" subsection with code example and design rationale
- **CLAUDE.md**: Add key management rule to LLM Integration section

🤖 Generated with [Claude Code](https://claude.com/claude-code)