### PR TITLE
docs: add CI Gemini integration test policy

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -578,6 +578,18 @@ For validation, compare anytomd-rs output against MarkItDown output on the same 
 
 CI includes optional live Gemini API integration tests that verify the `GeminiDescriber` works end-to-end with a real API call.
 
+**Trigger policy:**
+
+Gemini tests consume real API quota, so they are gated to prevent abuse from external PRs:
+
+| CI trigger | Gemini tests run? | Reason |
+|------------|-------------------|--------|
+| `push` (any branch) | Yes, automatically | Only repo owner/collaborators can push |
+| `pull_request` (default) | No | External PRs are untrusted — must be gated |
+| `pull_request` with `ci:gemini` label | Yes | Owner explicitly approved after code review |
+
+The owner must **review the PR diff before adding the `ci:gemini` label** — the label grants the PR's code access to the `GEMINI_API_KEY` secret.
+
 **Structure:**
 - Live tests live in `tests/test_gemini_live.rs` (or similar), gated behind the `gemini` feature
 - Each test reads the `GEMINI_API_KEY` environment variable — if absent, the test is skipped (not failed)


### PR DESCRIPTION
## Summary

Define CI Gemini integration test policy with cost protection against abuse.

## Key Changes

**CLAUDE.md:**
- Added "CI Gemini Integration Testing" subsection under LLM Integration
- Added model selection table (production: `gemini-3-flash-preview`, CI: `gemini-2.5-flash-lite`)
- Added label-based trigger policy (`ci:gemini` label required for external PRs)
- Documented rules: conditional execution, no hardcoded keys, allowed-to-fail for live API tests
- Updated CI section to include `--features gemini` checks and live API test step

**PRD.md:**
- Added model selection table to §4.9 (LLM-Assisted Image Description)
- Documented `with_model()` requirement for `GeminiDescriber`
- Added §8.4 (CI Gemini Live API Tests) with trigger policy, structure, and example test pattern

## Trigger Policy

| CI trigger | Gemini tests? | Reason |
|------------|---------------|--------|
| `push` (any branch) | Yes, automatically | Only owner/collaborators can push |
| `pull_request` (default) | No | External PRs are untrusted |
| `pull_request` + `ci:gemini` label | Yes | Owner approved after code review |

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify PRD.md renders correctly on GitHub
- [ ] Confirm no source code files were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)