### PR TITLE
feat: add ImageConverter for standalone image files

### DIFF
--- a/src/converter/image.rs
+++ b/src/converter/image.rs
@@ -1,0 +1,305 @@
+use crate::converter::{
+    mime_from_image, ConversionOptions, ConversionResult, ConversionWarning, Converter, WarningCode,
+};
+use crate::error::ConvertError;
+
+pub struct ImageConverter;
+
+/// Derive a file extension from a MIME type string.
+///
+/// Returns the extension without a dot (e.g., `"png"`, `"jpg"`).
+/// Falls back to an empty string if the MIME type is unrecognized.
+fn ext_from_mime(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/tiff" => "tiff",
+        "image/svg+xml" => "svg",
+        "image/heic" => "heic",
+        "image/avif" => "avif",
+        _ => "",
+    }
+}
+
+impl Converter for ImageConverter {
+    fn supported_extensions(&self) -> &[&str] {
+        &[
+            "png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif", "svg", "heic", "heif",
+            "avif", "image",
+        ]
+    }
+
+    fn convert(
+        &self,
+        data: &[u8],
+        options: &ConversionOptions,
+    ) -> Result<ConversionResult, ConvertError> {
+        let mut warnings = Vec::new();
+
+        // Derive a synthetic filename from magic bytes / MIME detection.
+        // We pass "image" as filename so extension fallback returns octet-stream,
+        // letting magic bytes take priority.
+        let mime = mime_from_image("image", data);
+        let ext = ext_from_mime(mime);
+        let filename = if ext.is_empty() {
+            "image".to_string()
+        } else {
+            format!("image.{}", ext)
+        };
+
+        // Check byte budget
+        if data.len() > options.max_total_image_bytes {
+            warnings.push(ConversionWarning {
+                code: WarningCode::ResourceLimitReached,
+                message: format!(
+                    "image size ({} bytes) exceeds limit ({})",
+                    data.len(),
+                    options.max_total_image_bytes
+                ),
+                location: Some(filename.clone()),
+            });
+            return Ok(ConversionResult {
+                markdown: String::new(),
+                title: None,
+                images: Vec::new(),
+                warnings,
+            });
+        }
+
+        // Build alt text via ImageDescriber if available
+        let alt_text = if let Some(ref describer) = options.image_describer {
+            let prompt = "Describe this image concisely for use as alt text.";
+            match describer.describe(data, mime, prompt) {
+                Ok(description) => description,
+                Err(e) => {
+                    warnings.push(ConversionWarning {
+                        code: WarningCode::SkippedElement,
+                        message: format!("image description failed: {}", e),
+                        location: Some(filename.clone()),
+                    });
+                    String::new()
+                }
+            }
+        } else {
+            String::new()
+        };
+
+        let markdown = format!("![{}]({})\n", alt_text, filename);
+
+        // Extract image data if requested
+        let images = if options.extract_images {
+            vec![(filename, data.to_vec())]
+        } else {
+            Vec::new()
+        };
+
+        Ok(ConversionResult {
+            markdown,
+            title: None,
+            images,
+            warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::converter::ImageDescriber;
+    use std::sync::Arc;
+
+    // Minimal PNG header (8 bytes)
+    const PNG_HEADER: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    // Minimal JPEG header (3 bytes, padded)
+    const JPEG_HEADER: [u8; 8] = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+
+    struct MockDescriber {
+        description: String,
+    }
+
+    impl ImageDescriber for MockDescriber {
+        fn describe(
+            &self,
+            _image_bytes: &[u8],
+            _mime_type: &str,
+            _prompt: &str,
+        ) -> Result<String, ConvertError> {
+            Ok(self.description.clone())
+        }
+    }
+
+    struct FailingDescriber;
+
+    impl ImageDescriber for FailingDescriber {
+        fn describe(
+            &self,
+            _image_bytes: &[u8],
+            _mime_type: &str,
+            _prompt: &str,
+        ) -> Result<String, ConvertError> {
+            Err(ConvertError::ImageDescriptionError {
+                reason: "API timeout".to_string(),
+            })
+        }
+    }
+
+    #[test]
+    fn test_image_supported_extensions() {
+        let converter = ImageConverter;
+        let exts = converter.supported_extensions();
+        for expected in &[
+            "png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif", "svg", "heic", "heif",
+            "avif", "image",
+        ] {
+            assert!(exts.contains(expected), "missing extension: {}", expected);
+        }
+    }
+
+    #[test]
+    fn test_image_simple_png() {
+        let converter = ImageConverter;
+        let result = converter
+            .convert(&PNG_HEADER, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image.png)\n");
+        assert!(result.images.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_image_simple_jpeg() {
+        let converter = ImageConverter;
+        let result = converter
+            .convert(&JPEG_HEADER, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image.jpg)\n");
+    }
+
+    #[test]
+    fn test_image_unknown_format() {
+        let converter = ImageConverter;
+        let data = b"unknown-format-data";
+        let result = converter
+            .convert(data, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image)\n");
+    }
+
+    #[test]
+    fn test_image_describer_replaces_alt_text() {
+        let converter = ImageConverter;
+        let options = ConversionOptions {
+            image_describer: Some(Arc::new(MockDescriber {
+                description: "A sunset over the ocean".to_string(),
+            })),
+            ..Default::default()
+        };
+        let result = converter.convert(&PNG_HEADER, &options).unwrap();
+        assert_eq!(result.markdown, "![A sunset over the ocean](image.png)\n");
+    }
+
+    #[test]
+    fn test_image_describer_error_keeps_empty_alt() {
+        let converter = ImageConverter;
+        let options = ConversionOptions {
+            image_describer: Some(Arc::new(FailingDescriber)),
+            ..Default::default()
+        };
+        let result = converter.convert(&PNG_HEADER, &options).unwrap();
+        assert_eq!(result.markdown, "![](image.png)\n");
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::SkippedElement
+                && w.message.contains("image description failed")));
+    }
+
+    #[test]
+    fn test_image_extract_images_flag() {
+        let converter = ImageConverter;
+        let options = ConversionOptions {
+            extract_images: true,
+            ..Default::default()
+        };
+        let result = converter.convert(&PNG_HEADER, &options).unwrap();
+        assert_eq!(result.images.len(), 1);
+        assert_eq!(result.images[0].0, "image.png");
+        assert_eq!(result.images[0].1, PNG_HEADER.to_vec());
+    }
+
+    #[test]
+    fn test_image_extract_images_default_false() {
+        let converter = ImageConverter;
+        let result = converter
+            .convert(&PNG_HEADER, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.images.is_empty());
+    }
+
+    #[test]
+    fn test_image_byte_budget_exceeded() {
+        let converter = ImageConverter;
+        let options = ConversionOptions {
+            max_total_image_bytes: 4, // Less than PNG_HEADER (8 bytes)
+            ..Default::default()
+        };
+        let result = converter.convert(&PNG_HEADER, &options).unwrap();
+        assert_eq!(result.markdown, "");
+        assert!(result.images.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::ResourceLimitReached));
+    }
+
+    #[test]
+    fn test_image_empty_input() {
+        let converter = ImageConverter;
+        let result = converter
+            .convert(&[], &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image)\n");
+    }
+
+    #[test]
+    fn test_ext_from_mime_known_types() {
+        assert_eq!(ext_from_mime("image/png"), "png");
+        assert_eq!(ext_from_mime("image/jpeg"), "jpg");
+        assert_eq!(ext_from_mime("image/gif"), "gif");
+        assert_eq!(ext_from_mime("image/webp"), "webp");
+        assert_eq!(ext_from_mime("image/bmp"), "bmp");
+        assert_eq!(ext_from_mime("image/tiff"), "tiff");
+        assert_eq!(ext_from_mime("image/svg+xml"), "svg");
+        assert_eq!(ext_from_mime("image/heic"), "heic");
+        assert_eq!(ext_from_mime("image/avif"), "avif");
+    }
+
+    #[test]
+    fn test_ext_from_mime_unknown() {
+        assert_eq!(ext_from_mime("application/octet-stream"), "");
+        assert_eq!(ext_from_mime("text/plain"), "");
+    }
+
+    #[test]
+    fn test_image_gif_magic_bytes() {
+        let converter = ImageConverter;
+        let data = b"GIF89a\x00\x00";
+        let result = converter
+            .convert(data, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image.gif)\n");
+    }
+
+    #[test]
+    fn test_image_webp_magic_bytes() {
+        let converter = ImageConverter;
+        let data = b"RIFF\x00\x00\x00\x00WEBP";
+        let result = converter
+            .convert(data, &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "![](image.webp)\n");
+    }
+}

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -3,6 +3,7 @@ pub mod docx;
 #[cfg(feature = "gemini")]
 pub mod gemini;
 pub mod html;
+pub mod image;
 pub mod json_conv;
 pub mod plain_text;
 pub mod pptx;
@@ -196,6 +197,8 @@ pub(crate) fn mime_from_image(filename: &str, data: &[u8]) -> &'static str {
         "bmp" => "image/bmp",
         "tiff" | "tif" => "image/tiff",
         "svg" => "image/svg+xml",
+        "heic" | "heif" => "image/heic",
+        "avif" => "image/avif",
         _ => "application/octet-stream",
     }
 }
@@ -314,6 +317,9 @@ mod tests {
         assert_eq!(mime_from_image("file.bmp", empty), "image/bmp");
         assert_eq!(mime_from_image("file.tiff", empty), "image/tiff");
         assert_eq!(mime_from_image("file.svg", empty), "image/svg+xml");
+        assert_eq!(mime_from_image("file.heic", empty), "image/heic");
+        assert_eq!(mime_from_image("file.heif", empty), "image/heic");
+        assert_eq!(mime_from_image("file.avif", empty), "image/avif");
         assert_eq!(
             mime_from_image("file.xyz", empty),
             "application/octet-stream"

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -74,6 +74,8 @@ fn detect_by_extension(path: &Path) -> Option<&'static str> {
         "xml" => Some("xml"),
         "txt" | "text" | "log" | "md" | "markdown" | "rst" | "ini" | "cfg" | "conf" | "toml"
         | "yaml" | "yml" => Some("txt"),
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tiff" | "tif" | "svg" | "heic"
+        | "heif" | "avif" => Some("image"),
         _ => None,
     }
 }
@@ -187,5 +189,45 @@ mod tests {
         let path = PathBuf::from("data.bin");
         let json_bytes = b"[1, 2, 3]";
         assert_eq!(detect_format(&path, json_bytes), Some("json"));
+    }
+
+    #[test]
+    fn test_detect_format_png_by_extension() {
+        let path = PathBuf::from("photo.png");
+        assert_eq!(detect_format(&path, &[]), Some("image"));
+    }
+
+    #[test]
+    fn test_detect_format_jpg_by_extension() {
+        let path = PathBuf::from("photo.jpg");
+        assert_eq!(detect_format(&path, &[]), Some("image"));
+    }
+
+    #[test]
+    fn test_detect_format_jpeg_by_extension() {
+        let path = PathBuf::from("photo.jpeg");
+        assert_eq!(detect_format(&path, &[]), Some("image"));
+    }
+
+    #[test]
+    fn test_detect_format_svg_by_extension() {
+        let path = PathBuf::from("icon.svg");
+        assert_eq!(detect_format(&path, &[]), Some("image"));
+    }
+
+    #[test]
+    fn test_detect_format_image_variants() {
+        for ext in &[
+            "png", "jpg", "jpeg", "gif", "webp", "bmp", "tiff", "tif", "svg", "heic", "heif",
+            "avif",
+        ] {
+            let path = PathBuf::from(format!("file.{}", ext));
+            assert_eq!(
+                detect_format(&path, &[]),
+                Some("image"),
+                "expected 'image' for .{}",
+                ext
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub fn convert_bytes(
     use converter::csv_conv::CsvConverter;
     use converter::docx::DocxConverter;
     use converter::html::HtmlConverter;
+    use converter::image::ImageConverter;
     use converter::json_conv::JsonConverter;
     use converter::plain_text::PlainTextConverter;
     use converter::pptx::PptxConverter;
@@ -78,6 +79,7 @@ pub fn convert_bytes(
         Box::new(XmlConverter),
         Box::new(CsvConverter),
         Box::new(HtmlConverter),
+        Box::new(ImageConverter),
         Box::new(PlainTextConverter),
     ];
 


### PR DESCRIPTION
## Summary

- Add a dedicated `ImageConverter` for standalone image files (PNG, JPEG, GIF, WebP, BMP, TIFF, SVG, HEIC, HEIF, AVIF) so they produce Markdown output instead of returning `UnsupportedFormat`
- Register image file extensions in `detection.rs` returning generic `"image"` format string
- Extend `mime_from_image()` to support HEIC/HEIF and AVIF MIME types
- With `ImageDescriber`: `![description](image.png)`, without: `![](image.png)`
- Supports `extract_images` flag and `max_total_image_bytes` byte budget

## Key changes

| File | Change |
|------|--------|
| `src/converter/image.rs` | New `ImageConverter` with full `Converter` trait impl |
| `src/detection.rs` | Image extensions → `"image"` format detection |
| `src/converter/mod.rs` | Add `pub mod image`, extend MIME map for HEIC/AVIF |
| `src/lib.rs` | Register `ImageConverter` before `PlainTextConverter` |
| `tests/test_image_describer.rs` | 5 new integration tests for standalone images |

## Test plan

- [x] 14 unit tests in `src/converter/image.rs` (extensions, PNG/JPEG/GIF/WebP, describer, extract, budget, empty input, MIME mapping)
- [x] 5 detection tests in `src/detection.rs` (PNG, JPG, JPEG, SVG, all 12 variants)
- [x] 3 MIME tests for HEIC/HEIF/AVIF in `src/converter/mod.rs`
- [x] 5 integration tests in `tests/test_image_describer.rs` (with/without describer, extract, generic extension, JPEG)
- [x] All 286 existing tests still pass (296 with gemini feature)
- [x] `cargo clippy -- -D warnings` clean (with and without gemini)
- [x] `cargo fmt --check` clean
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)