### PR TITLE
fix: resolve 4 high-severity bugs causing data loss and incorrect output

### DIFF
--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -203,6 +203,31 @@ pub(crate) fn mime_from_image(filename: &str, data: &[u8]) -> &'static str {
     }
 }
 
+/// Replace a single image placeholder with its description in the markdown.
+///
+/// Finds the first occurrence of `![{placeholder}]({filename})` and replaces the
+/// placeholder with the description. Uses unique placeholders to avoid ambiguity
+/// with duplicate filenames.
+pub(crate) fn replace_image_alt_by_placeholder(
+    markdown: &str,
+    placeholder: &str,
+    description: &str,
+    filename: &str,
+) -> String {
+    let target = format!("![{placeholder}]({filename})");
+    let replacement = format!("![{description}]({filename})");
+    // Replace exactly ONE occurrence
+    if let Some(pos) = markdown.find(&target) {
+        let mut result = String::with_capacity(markdown.len());
+        result.push_str(&markdown[..pos]);
+        result.push_str(&replacement);
+        result.push_str(&markdown[pos + target.len()..]);
+        result
+    } else {
+        markdown.to_string()
+    }
+}
+
 /// Trait implemented by each format-specific converter.
 pub trait Converter {
     /// Returns the file extensions this converter supports (e.g., `["docx"]`).


### PR DESCRIPTION
## Summary

Fixes 4 HIGH-severity bugs found during a codebase audit that cause data loss or incorrect output in real-world document conversions.

- **Bug 1 — JSON heuristic overrides file extension** (`detection.rs`): Move JSON content heuristic after extension check so `.txt` files starting with `{` are no longer misdetected as JSON
- **Bug 2 — Ordered list numbering never resets** (`docx.rs`): Use per-list `numId` as counter key instead of a global key, so separate ordered lists restart at 1
- **Bug 3 — Broken bold/italic markers from per-run formatting** (`docx.rs`): Merge adjacent runs with the same formatting before applying `**`/`*` markers, fixing `**Hello** **World**` → `**Hello World**`
- **Bug 4 — Image description replacement corrupts markdown** (`docx.rs`, `pptx.rs`, `xlsx.rs`, `mod.rs`): Replace fragile `rfind("![")` approach with unique per-image placeholders, eliminating content corruption when duplicate filenames exist

## Key changes

- `src/detection.rs`: Reorder detection priority to magic bytes → extension → JSON heuristic
- `src/converter/docx.rs`: Add `num_id` to list items, add `RunSegment` merging, add `ImageInfo` placeholder system
- `src/converter/pptx.rs`: Switch to `ImageInfo` placeholder system in `render_slide` and `convert()`
- `src/converter/xlsx.rs`: Switch to `ImageInfo` placeholder system in image extraction
- `src/converter/mod.rs`: Add shared `replace_image_alt_by_placeholder()` helper

## Test plan

- [x] 3 new tests for Bug 1 (detection priority)
- [x] 1 new test for Bug 2 (list numbering restart)
- [x] 4 new tests for Bug 3 (run formatting merge)
- [x] 1 new test for Bug 4 (duplicate image filenames)
- [x] All 295 unit tests pass
- [x] All 33 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)