### PR TITLE
docs: remove Comparison with MarkItDown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,16 +168,6 @@ Set `strict: true` in `ConversionOptions` to turn recoverable failures into erro
 
 Warning codes: `SkippedElement`, `UnsupportedFeature`, `ResourceLimitReached`, `MalformedSegment`.
 
-## Comparison with MarkItDown
-
-| | anytomd | MarkItDown |
-|---|---------|------------|
-| Language | Pure Rust | Python |
-| Runtime dependency | None | Python interpreter |
-| DOCX conversion | Direct OOXML-to-Markdown | DOCX → HTML → Markdown (two-step) |
-| Binary size | Single static binary | ~50 MB with bundled Python |
-| Integration | `cargo add anytomd` | PyO3/subprocess/bundled runtime |
-
 ## Development
 
 ### Build and Test


### PR DESCRIPTION
## Summary
- Remove the "Comparison with MarkItDown" table from README
- The "Why?" section already explains the motivation for anytomd clearly
- A direct comparison table can come across as aggressive toward the upstream project we draw inspiration from

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)