### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ target
 
 # Reference repos (for development analysis only)
 reference/
+
+# macOS
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "calamine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,16 @@
 [package]
 name = "anytomd"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.90"
 license = "Apache-2.0"
 description = "Pure Rust library that converts various document formats into Markdown"
 repository = "https://github.com/developer0hye/anytomd-rs"
+homepage = "https://github.com/developer0hye/anytomd-rs"
+documentation = "https://docs.rs/anytomd"
+readme = "README.md"
+keywords = ["markdown", "converter", "document", "llm"]
+categories = ["parser-implementations", "text-processing"]
 
 [features]
 default = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Provides a reproducible Linux build/test environment.
 # Usage: see docker-compose.yml or the "Docker Development" section in CLAUDE.md.
 
-ARG RUST_VERSION=1.83.0
+ARG RUST_VERSION=1.90.0
 
 # ------------------------------------------------------------
 # Stage 1: chef — install cargo-chef for dependency caching


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.2.0 for crates.io publish
- Add crates.io metadata: `readme`, `keywords`, `categories`, `homepage`, `documentation`
- Add `.DS_Store` to `.gitignore`
- Bump MSRV from 1.75 to 1.90 (both `Cargo.toml` and `Dockerfile`)

## What's new in 0.2.0
Since 0.1.0, the following features have been added:
- HTML converter
- XML converter
- XLS (legacy Excel) support
- Image converter with `ImageDescriber` trait (optional LLM-based image descriptions)
- `GeminiDescriber` (behind `gemini` feature flag)
- Resource limits (`ConversionOptions`)
- Non-OOXML ZIP rejection
- Encoding detection improvements

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — 296 unit + all integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo publish --dry-run` succeeds
- [ ] CI passes on all platforms
- [ ] `cargo publish` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)