### PR TITLE
chore: release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.90"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version to 0.3.0 for the CLI addition in #34

## Key changes

- `Cargo.toml`: version 0.2.0 → 0.3.0
- `Cargo.lock`: updated accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)