### PR TITLE
feat: include Gemini by default, auto-enable via GEMINI_API_KEY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - name: Lint (gemini feature)
-        run: cargo clippy --features gemini -- -D warnings
-
-      - name: Run tests (gemini feature)
-        run: cargo test --features gemini
-
       - name: Build release
         run: cargo build --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,6 @@ readme = "README.md"
 keywords = ["markdown", "converter", "document", "llm"]
 categories = ["parser-implementations", "text-processing"]
 
-[features]
-default = []
-gemini = ["dep:ureq", "dep:base64"]
-
 [dependencies]
 zip = "2"
 quick-xml = "0.37"
@@ -28,8 +24,8 @@ scraper = "0.22"
 encoding_rs = "0.8"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
-ureq = { version = "3", optional = true }
-base64 = { version = "0.22", optional = true }
+ureq = "3"
+base64 = "0.22"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -1,6 +1,5 @@
 pub mod csv_conv;
 pub mod docx;
-#[cfg(feature = "gemini")]
 pub mod gemini;
 pub mod html;
 pub mod image;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ pub use converter::{
 };
 pub use error::ConvertError;
 
-#[cfg(feature = "gemini")]
 pub mod gemini {
     pub use crate::converter::gemini::GeminiDescriber;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,15 +44,12 @@ fn build_options(cli: &Cli) -> ConversionOptions {
         ..Default::default()
     };
 
-    #[cfg(feature = "gemini")]
-    {
-        if let Ok(describer) = anytomd::gemini::GeminiDescriber::from_env() {
-            eprintln!("info: using Gemini for image descriptions (GEMINI_API_KEY detected)");
-            return ConversionOptions {
-                image_describer: Some(std::sync::Arc::new(describer)),
-                ..options
-            };
-        }
+    if let Ok(describer) = anytomd::gemini::GeminiDescriber::from_env() {
+        eprintln!("info: using Gemini for image descriptions (GEMINI_API_KEY detected)");
+        return ConversionOptions {
+            image_describer: Some(std::sync::Arc::new(describer)),
+            ..options
+        };
     }
 
     options


### PR DESCRIPTION
## Summary

- Gemini image describer is now a default dependency — no `--features gemini` needed
- CLI automatically uses Gemini when `GEMINI_API_KEY` env var is set (zero-config)
- Removed all `#[cfg(feature = "gemini")]` gates, simplified CI

## Key changes

- **`Cargo.toml`**: `ureq`/`base64` are now regular (non-optional) deps, `[features]` section removed
- **`src/lib.rs`**, **`src/converter/mod.rs`**: Removed `#[cfg(feature = "gemini")]` guards
- **`src/main.rs`**: `build_options()` auto-detects `GEMINI_API_KEY` env var
- **`.github/workflows/ci.yml`**: Removed separate gemini lint/test steps (now always included)
- **`README.md`**: Simplified install/usage — no feature flags needed

## Test plan

- [x] 306 unit tests + 53 integration tests pass (gemini tests now always run)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)