### PR TITLE
refactor: extract shared OOXML utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -4,6 +4,7 @@ pub mod gemini;
 pub mod html;
 pub mod image;
 pub mod json_conv;
+pub(crate) mod ooxml_utils;
 pub mod plain_text;
 pub mod pptx;
 pub mod xlsx;

--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -1,0 +1,404 @@
+use std::collections::HashMap;
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+
+use crate::converter::{
+    replace_image_alt_by_placeholder, ConversionWarning, ImageDescriber, WarningCode,
+};
+
+/// A resolved relationship entry from a .rels file.
+#[derive(Debug, Clone)]
+pub(crate) struct Relationship {
+    pub(crate) target: String,
+    pub(crate) rel_type: String,
+}
+
+/// Information about an image found during conversion.
+#[derive(Debug, Clone)]
+pub(crate) struct ImageInfo {
+    pub(crate) placeholder: String,
+    pub(crate) original_alt: String,
+    pub(crate) filename: String,
+}
+
+/// Parse a .rels XML file to extract relationship ID -> Relationship mapping.
+pub(crate) fn parse_relationships(xml: &str) -> HashMap<String, Relationship> {
+    let mut rels = HashMap::new();
+    let mut reader = Reader::from_str(xml);
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+
+                if local_str == "Relationship" {
+                    let mut id = None;
+                    let mut target = None;
+                    let mut rel_type = String::new();
+
+                    for attr in e.attributes().flatten() {
+                        let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
+                        let val = String::from_utf8_lossy(&attr.value).to_string();
+                        match key {
+                            "Id" => id = Some(val),
+                            "Target" => target = Some(val),
+                            "Type" => rel_type = val,
+                            _ => {}
+                        }
+                    }
+
+                    if let (Some(id), Some(target)) = (id, target) {
+                        rels.insert(id, Relationship { target, rel_type });
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    rels
+}
+
+/// Derive the .rels path for a given file path.
+///
+/// Example: `ppt/slides/slide1.xml` -> `ppt/slides/_rels/slide1.xml.rels`
+pub(crate) fn derive_rels_path(file_path: &str) -> String {
+    if let Some(pos) = file_path.rfind('/') {
+        let dir = &file_path[..pos];
+        let filename = &file_path[pos + 1..];
+        format!("{dir}/_rels/{filename}.rels")
+    } else {
+        format!("_rels/{file_path}.rels")
+    }
+}
+
+/// Resolve a relative path target against a base directory path.
+///
+/// Example: base_dir=`xl/drawings`, target=`../media/image1.png`
+///          -> `xl/media/image1.png`
+pub(crate) fn resolve_relative_path(base_dir: &str, target: &str) -> String {
+    if !target.starts_with("../") {
+        if base_dir.is_empty() {
+            return target.to_string();
+        }
+        return format!("{base_dir}/{target}");
+    }
+
+    let mut parts: Vec<&str> = base_dir.split('/').collect();
+
+    let mut remaining = target;
+    while let Some(rest) = remaining.strip_prefix("../") {
+        parts.pop();
+        remaining = rest;
+    }
+
+    if parts.is_empty() {
+        remaining.to_string()
+    } else {
+        format!("{}/{remaining}", parts.join("/"))
+    }
+}
+
+/// Resolve a relative path target against a base file path.
+///
+/// Strips the filename from `base_file` to get the directory, then delegates
+/// to `resolve_relative_path`.
+///
+/// Example: base_file=`ppt/slides/slide1.xml`, target=`../media/image1.png`
+///          -> `ppt/media/image1.png`
+pub(crate) fn resolve_relative_to_file(base_file: &str, target: &str) -> String {
+    if !target.starts_with("../") {
+        // Absolute or same-directory target
+        if let Some(pos) = base_file.rfind('/') {
+            return format!("{}/{target}", &base_file[..pos]);
+        }
+        return target.to_string();
+    }
+
+    // Walk up for each "../" prefix
+    let mut base_parts: Vec<&str> = base_file.split('/').collect();
+    // Remove the filename from base
+    base_parts.pop();
+
+    let mut target_remaining = target;
+    while let Some(rest) = target_remaining.strip_prefix("../") {
+        base_parts.pop();
+        target_remaining = rest;
+    }
+
+    if base_parts.is_empty() {
+        target_remaining.to_string()
+    } else {
+        format!("{}/{target_remaining}", base_parts.join("/"))
+    }
+}
+
+/// Replace image placeholders in markdown with descriptions from the describer,
+/// or fall back to the original alt text.
+pub(crate) fn resolve_image_placeholders(
+    markdown: &mut String,
+    image_infos: &[ImageInfo],
+    image_bytes: &HashMap<String, Vec<u8>>,
+    describer: Option<&dyn ImageDescriber>,
+    warnings: &mut Vec<ConversionWarning>,
+) {
+    if let Some(describer) = describer {
+        for info in image_infos {
+            if let Some(img_data) = image_bytes.get(&info.filename) {
+                let mime = crate::converter::mime_from_image(&info.filename, img_data);
+                let prompt = "Describe this image concisely for use as alt text.";
+                match describer.describe(img_data, mime, prompt) {
+                    Ok(description) => {
+                        *markdown = replace_image_alt_by_placeholder(
+                            markdown,
+                            &info.placeholder,
+                            &description,
+                            &info.filename,
+                        );
+                    }
+                    Err(e) => {
+                        *markdown = replace_image_alt_by_placeholder(
+                            markdown,
+                            &info.placeholder,
+                            &info.original_alt,
+                            &info.filename,
+                        );
+                        warnings.push(ConversionWarning {
+                            code: WarningCode::SkippedElement,
+                            message: format!(
+                                "image description failed for '{}': {}",
+                                info.filename, e
+                            ),
+                            location: Some(info.filename.clone()),
+                        });
+                    }
+                }
+            } else {
+                *markdown = replace_image_alt_by_placeholder(
+                    markdown,
+                    &info.placeholder,
+                    &info.original_alt,
+                    &info.filename,
+                );
+            }
+        }
+    } else {
+        for info in image_infos {
+            *markdown = replace_image_alt_by_placeholder(
+                markdown,
+                &info.placeholder,
+                &info.original_alt,
+                &info.filename,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_relationships_basic() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com" TargetMode="External"/></Relationships>"#;
+        let rels = parse_relationships(xml);
+        assert_eq!(rels.len(), 2);
+
+        let r1 = rels.get("rId1").unwrap();
+        assert_eq!(r1.target, "media/image1.png");
+        assert!(r1.rel_type.contains("image"));
+
+        let r2 = rels.get("rId2").unwrap();
+        assert_eq!(r2.target, "https://example.com");
+        assert!(r2.rel_type.contains("hyperlink"));
+    }
+
+    #[test]
+    fn test_parse_relationships_empty() {
+        let xml = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>"#;
+        let rels = parse_relationships(xml);
+        assert!(rels.is_empty());
+    }
+
+    #[test]
+    fn test_parse_relationships_missing_id() {
+        let xml = r#"<Relationships><Relationship Type="foo" Target="bar"/></Relationships>"#;
+        let rels = parse_relationships(xml);
+        assert!(rels.is_empty());
+    }
+
+    #[test]
+    fn test_parse_relationships_missing_target() {
+        let xml = r#"<Relationships><Relationship Id="rId1" Type="foo"/></Relationships>"#;
+        let rels = parse_relationships(xml);
+        assert!(rels.is_empty());
+    }
+
+    #[test]
+    fn test_derive_rels_path_with_directory() {
+        assert_eq!(
+            derive_rels_path("ppt/slides/slide1.xml"),
+            "ppt/slides/_rels/slide1.xml.rels"
+        );
+        assert_eq!(
+            derive_rels_path("xl/drawings/drawing1.xml"),
+            "xl/drawings/_rels/drawing1.xml.rels"
+        );
+    }
+
+    #[test]
+    fn test_derive_rels_path_no_directory() {
+        assert_eq!(derive_rels_path("file.xml"), "_rels/file.xml.rels");
+    }
+
+    #[test]
+    fn test_resolve_relative_path_same_dir() {
+        assert_eq!(
+            resolve_relative_path("xl/drawings", "image1.png"),
+            "xl/drawings/image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_path_parent_dir() {
+        assert_eq!(
+            resolve_relative_path("xl/drawings", "../media/image1.png"),
+            "xl/media/image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_path_empty_base() {
+        assert_eq!(resolve_relative_path("", "image1.png"), "image1.png");
+    }
+
+    #[test]
+    fn test_resolve_relative_to_file_same_dir() {
+        assert_eq!(
+            resolve_relative_to_file("ppt/slides/slide1.xml", "image1.png"),
+            "ppt/slides/image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_to_file_parent_dir() {
+        assert_eq!(
+            resolve_relative_to_file("ppt/slides/slide1.xml", "../media/image1.png"),
+            "ppt/media/image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_to_file_no_dir() {
+        assert_eq!(
+            resolve_relative_to_file("slide.xml", "image1.png"),
+            "image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_image_placeholders_no_describer() {
+        let mut md = "![__img_0__](cat.png)\n![__img_1__](dog.png)".to_string();
+        let infos = vec![
+            ImageInfo {
+                placeholder: "__img_0__".to_string(),
+                original_alt: "A cat".to_string(),
+                filename: "cat.png".to_string(),
+            },
+            ImageInfo {
+                placeholder: "__img_1__".to_string(),
+                original_alt: "A dog".to_string(),
+                filename: "dog.png".to_string(),
+            },
+        ];
+        let image_bytes = HashMap::new();
+        let mut warnings = Vec::new();
+        resolve_image_placeholders(&mut md, &infos, &image_bytes, None, &mut warnings);
+        assert!(md.contains("![A cat](cat.png)"));
+        assert!(md.contains("![A dog](dog.png)"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_image_placeholders_with_describer() {
+        use crate::converter::ImageDescriber;
+        use crate::error::ConvertError;
+
+        struct MockDescriber;
+        impl ImageDescriber for MockDescriber {
+            fn describe(
+                &self,
+                _image_bytes: &[u8],
+                _mime_type: &str,
+                _prompt: &str,
+            ) -> Result<String, ConvertError> {
+                Ok("LLM description".to_string())
+            }
+        }
+
+        let mut md = "![__img_0__](cat.png)".to_string();
+        let infos = vec![ImageInfo {
+            placeholder: "__img_0__".to_string(),
+            original_alt: "A cat".to_string(),
+            filename: "cat.png".to_string(),
+        }];
+        let mut image_bytes = HashMap::new();
+        image_bytes.insert("cat.png".to_string(), vec![0x89, b'P', b'N', b'G']);
+        let mut warnings = Vec::new();
+        let describer = MockDescriber;
+        resolve_image_placeholders(
+            &mut md,
+            &infos,
+            &image_bytes,
+            Some(&describer),
+            &mut warnings,
+        );
+        assert!(md.contains("![LLM description](cat.png)"));
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_image_placeholders_describer_error_fallback() {
+        use crate::converter::ImageDescriber;
+        use crate::error::ConvertError;
+
+        struct FailingDescriber;
+        impl ImageDescriber for FailingDescriber {
+            fn describe(
+                &self,
+                _image_bytes: &[u8],
+                _mime_type: &str,
+                _prompt: &str,
+            ) -> Result<String, ConvertError> {
+                Err(ConvertError::ImageDescriptionError {
+                    reason: "API error".to_string(),
+                })
+            }
+        }
+
+        let mut md = "![__img_0__](cat.png)".to_string();
+        let infos = vec![ImageInfo {
+            placeholder: "__img_0__".to_string(),
+            original_alt: "A cat".to_string(),
+            filename: "cat.png".to_string(),
+        }];
+        let mut image_bytes = HashMap::new();
+        image_bytes.insert("cat.png".to_string(), vec![0x89, b'P', b'N', b'G']);
+        let mut warnings = Vec::new();
+        let describer = FailingDescriber;
+        resolve_image_placeholders(
+            &mut md,
+            &infos,
+            &image_bytes,
+            Some(&describer),
+            &mut warnings,
+        );
+        assert!(md.contains("![A cat](cat.png)"));
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("image description failed"));
+    }
+}


### PR DESCRIPTION
## Summary

- Extract ~430 lines of duplicated code from `docx.rs`, `pptx.rs`, and `xlsx.rs` into two shared modules
- New `src/converter/ooxml_utils.rs` consolidates OOXML-specific shared logic: relationship parsing, path resolution, image placeholder handling
- Extended `src/zip_utils.rs` with `read_zip_text()` and `read_zip_bytes()` for format-agnostic ZIP I/O
- No public API changes; purely internal refactoring to reduce maintenance burden

## Key Changes

| File | Change |
|------|--------|
| `src/converter/ooxml_utils.rs` | **New**: `Relationship`, `ImageInfo`, `parse_relationships`, `derive_rels_path`, `resolve_relative_path`, `resolve_relative_to_file`, `resolve_image_placeholders` + 15 unit tests |
| `src/zip_utils.rs` | Added `read_zip_text`, `read_zip_bytes` |
| `src/converter/mod.rs` | Registered `ooxml_utils` module |
| `src/converter/docx.rs` | Removed 6 local items, replaced with shared imports (-120 lines) |
| `src/converter/pptx.rs` | Removed 8 local items, replaced with shared imports (-170 lines) |
| `src/converter/xlsx.rs` | Removed 6 local items, unified `parse_rels`→`parse_relationships` (-160 lines) |

## Test plan

- [x] All 324 unit tests pass (including 15 new tests in `ooxml_utils.rs`)
- [x] All 59 integration tests pass unchanged
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)