### PR TITLE
chore: release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.90"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0

## Changes since 0.4.0

- **refactor**: Extract shared OOXML utilities from docx/pptx/xlsx converters into `ooxml_utils.rs` and `zip_utils.rs`, eliminating ~430 lines of duplicated code (PR #39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)