### PR TITLE
refactor: split convert() into convert_inner() for async support

### DIFF
--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -22,6 +22,16 @@ pub(crate) struct ImageInfo {
     pub(crate) filename: String,
 }
 
+/// Collected image data from a converter's parse phase, ready for resolution.
+///
+/// Converters populate this during `convert_inner()` so that image description
+/// (sync or async) can be performed separately from document parsing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PendingImageResolution {
+    pub(crate) infos: Vec<ImageInfo>,
+    pub(crate) bytes: HashMap<String, Vec<u8>>,
+}
+
 /// Parse a .rels XML file to extract relationship ID -> Relationship mapping.
 pub(crate) fn parse_relationships(xml: &str) -> HashMap<String, Relationship> {
     let mut rels = HashMap::new();


### PR DESCRIPTION
## Summary
- Extract `convert_inner()` from DocxConverter, PptxConverter, XlsxConverter, and ImageConverter
- Add `PendingImageResolution` struct to `ooxml_utils` that bundles image infos and bytes for deferred resolution
- Each `convert()` now delegates to `convert_inner()` + `resolve_image_placeholders()`, preserving identical behavior
- ImageConverter adopts the same placeholder-based approach used by OOXML converters

## Why
This separation enables a future async API to reuse the same document parsing logic with concurrent image description via `AsyncImageDescriber`. The parse phase (`convert_inner()`) is decoupled from the resolution phase, so sync and async paths can share parsing while differing only in how they resolve image placeholders.

## Key changes
| File | Change |
|------|--------|
| `ooxml_utils.rs` | Add `PendingImageResolution` struct |
| `docx.rs` | Extract `convert_inner()`, `convert()` delegates |
| `pptx.rs` | Extract `convert_inner()`, collect all image data across slides before resolution |
| `xlsx.rs` | Extract `convert_inner()`, `convert()` delegates |
| `image.rs` | Adopt placeholder approach, extract `convert_inner()` |

## Test plan
- [x] All 339 unit tests pass
- [x] All 50 integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Pure refactor — zero behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)