### PR TITLE
feat: add AsyncGeminiDescriber (async-gemini feature)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub use error::ConvertError;
 
 pub mod gemini {
     pub use crate::converter::gemini::GeminiDescriber;
+
+    #[cfg(feature = "async-gemini")]
+    pub use crate::converter::gemini::AsyncGeminiDescriber;
 }
 
 use std::path::Path;


### PR DESCRIPTION
## Summary

- Add `AsyncGeminiDescriber` struct implementing `AsyncImageDescriber` using `reqwest` for non-blocking HTTP
- Same API as sync `GeminiDescriber`: `new()`, `from_env()`, `with_model()`
- Reuses existing `parse_response()` for consistent Gemini response handling
- Uses shared `reqwest::Client` for connection pooling across concurrent descriptions
- Re-exported under `anytomd::gemini::AsyncGeminiDescriber`

## Key changes

- `src/converter/gemini.rs`: `AsyncGeminiDescriber` + `AsyncImageDescriber` impl (behind `async-gemini` feature)
- `src/lib.rs`: conditional re-export in `gemini` module

## Test plan

- [x] 348 tests pass with `--features async-gemini` (339 base + 3 async + 6 async-gemini)
- [x] 339 tests pass without features (default build unaffected)
- [x] Clippy clean with `--features async-gemini`
- [x] Doc-tests compile (including `AsyncGeminiDescriber` example)
- [x] Debug output redacts API key
- [x] Trait object compatibility verified
- [ ] CI passes on all platforms

Depends on #45 (`feat/async-image-describer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)