### PR TITLE
docs: add async feature documentation and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,17 @@ jobs:
       - name: Build release
         run: cargo build --release
 
+      - name: Lint (async feature)
+        run: cargo clippy --features async -- -D warnings
+
+      - name: Test (async feature)
+        run: cargo test --features async
+
+      - name: Lint (async-gemini feature)
+        run: cargo clippy --features async-gemini -- -D warnings
+
+      - name: Test (async-gemini feature)
+        run: cargo test --features async-gemini
+
       - name: CLI smoke test
         run: echo "hello" | cargo run -- --format txt


### PR DESCRIPTION
## Summary

- Add feature flags table, async usage examples, and async API signatures to README.md
- Add async architecture documentation (two-phase conversion, trait design) to CLAUDE.md
- Add `async` and `async-gemini` feature lint and test steps to CI workflow

## Key changes

- **README.md**: Feature flags table, `AsyncGeminiDescriber` usage example, `convert_file_async`/`convert_bytes_async` API docs
- **CLAUDE.md**: Async Image Description section with architecture details, updated CI section
- **.github/workflows/ci.yml**: 4 new CI steps (lint + test for `async` and `async-gemini` features)

## Test plan

- [x] Documentation is accurate and matches implementation
- [x] CI workflow YAML is valid
- [ ] CI passes on all platforms with new async feature checks

Depends on #46 (`feat/async-gemini-describer`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)