### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.90"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from 0.6.0 to 0.6.1

## Changes since v0.6.0

### Refactoring
- Standardize converter module naming: `csv_conv.rs` -> `csv.rs`, `json_conv.rs` -> `json.rs`, `xml_conv.rs` -> `xml.rs` (#50)
- Extract shared `normalize()` test utility to `tests/common/mod.rs`, eliminating ~135 lines of duplication (#50)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)