### PR TITLE
docs: sync CLAUDE.md phase and fix gemini feature references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 **anytomd** (repository: `anytomd-rs`) is a pure Rust reimplementation of Microsoft's [MarkItDown](https://github.com/microsoft/markitdown) Python library. It converts various document formats (DOCX, PPTX, XLSX, PDF, HTML, CSV, JSON, etc.) into Markdown, targeting LLM consumption. A single `cargo add anytomd` with zero external runtime.
 
-**Current phase: MVP (v0.1.0)** — DOCX, PPTX, XLSX, CSV, JSON, Plain Text. See [TECH_SPEC.md](./TECH_SPEC.md) for full architecture and milestones.
+**Current phase:** 9 converters (DOCX, PPTX, XLSX, XLS, HTML, CSV, JSON, XML, Images, Plain Text) + async image description + Gemini integration. See [TECH_SPEC.md](./TECH_SPEC.md) for full architecture and milestones.
 
 ---
 
@@ -255,6 +255,6 @@ CI must pass on every push/PR. Matrix: `ubuntu-latest`, `macos-latest`, `windows
 `cargo clippy --features async -- -D warnings` → `cargo test --features async` → `cargo clippy --features async-gemini -- -D warnings` → `cargo test --features async-gemini`
 
 **Gemini checks** (on `push` or `ci:gemini` labeled PRs only):
-`cargo test --features gemini` → `cargo clippy --features gemini -- -D warnings` → `cargo test --features gemini --test test_gemini_live` (allowed-to-fail)
+`cargo test --test test_gemini_live` (allowed-to-fail — depends on `GEMINI_API_KEY` secret)
 
 **Rules:** Never merge code that breaks CI. Gemini live API failures do not block merging. New converters without tests = incomplete CI.

--- a/src/converter/gemini.rs
+++ b/src/converter/gemini.rs
@@ -8,7 +8,8 @@ use std::pin::Pin;
 
 /// Built-in `ImageDescriber` that uses the Google Gemini API.
 ///
-/// Requires the `gemini` feature flag.
+/// Always available (no feature flag required). For the async variant,
+/// see `AsyncGeminiDescriber` (requires the `async-gemini` feature).
 ///
 /// # Example
 ///


### PR DESCRIPTION
## Summary

- Updated project phase description from outdated "MVP (v0.1.0)" to reflect current state (9 converters + async image description + Gemini integration) without pinning a specific version number
- Removed non-existent `--features gemini` flag references from CI documentation — the sync `GeminiDescriber` is always compiled, no feature gate needed
- Fixed `gemini.rs` doc comment to clarify that `GeminiDescriber` requires no feature flag (only `AsyncGeminiDescriber` needs `async-gemini`)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 339 unit tests + integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Doc-test for `GeminiDescriber` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)