### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "anytomd"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.90"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version to v0.6.2 (patch release)
- Includes documentation and doc comment fixes from #52

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)