### PR TITLE
feat: add CodeConverter for source code files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A pure Rust tool and library that converts various document formats into Markdow
 | JSON | `.json` | Pretty-printed in fenced code blocks |
 | XML | `.xml` | Pretty-printed in fenced code blocks |
 | Images | `.png`, `.jpg`, `.gif`, `.webp`, `.bmp`, `.tiff`, `.svg`, `.heic`, `.avif` | Optional LLM-based alt text via `ImageDescriber` |
+| Code | `.py`, `.rs`, `.js`, `.ts`, `.c`, `.cpp`, `.go`, `.java`, `.rb`, `.swift`, `.sh`, ... | Fenced code blocks with language identifier |
 | Plain Text | `.txt`, `.md`, `.rst`, `.log`, `.toml`, `.yaml`, `.ini`, etc. | Passthrough with encoding detection (UTF-8, UTF-16, Windows-1252) |
 
 **Note on PDF:** PDF conversion is intentionally out of scope. Gemini, ChatGPT, and Claude already provide native PDF support (with plan/model-specific limits), so anytomd focuses on formats that still benefit from dedicated Markdown conversion.

--- a/src/converter/code.rs
+++ b/src/converter/code.rs
@@ -1,0 +1,250 @@
+use crate::converter::{ConversionOptions, ConversionResult, Converter};
+use crate::error::ConvertError;
+
+pub struct CodeConverter;
+
+/// Map a file extension to its fenced code block language identifier.
+fn language_for_extension(ext: &str) -> Option<&'static str> {
+    match ext {
+        "c" | "h" => Some("c"),
+        "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" => Some("cpp"),
+        "py" | "pyw" => Some("python"),
+        "js" | "mjs" | "cjs" => Some("javascript"),
+        "jsx" => Some("jsx"),
+        "ts" | "mts" | "cts" => Some("typescript"),
+        "tsx" => Some("tsx"),
+        "rs" => Some("rust"),
+        "go" => Some("go"),
+        "java" => Some("java"),
+        "kt" | "kts" => Some("kotlin"),
+        "rb" => Some("ruby"),
+        "swift" => Some("swift"),
+        "cs" => Some("csharp"),
+        "php" => Some("php"),
+        "sh" | "bash" | "zsh" | "fish" => Some("bash"),
+        "pl" | "pm" => Some("perl"),
+        "lua" => Some("lua"),
+        "r" => Some("r"),
+        "scala" => Some("scala"),
+        "dart" => Some("dart"),
+        "ex" | "exs" => Some("elixir"),
+        "erl" => Some("erlang"),
+        "hs" => Some("haskell"),
+        "ml" | "mli" => Some("ocaml"),
+        "sql" => Some("sql"),
+        "m" | "mm" => Some("objectivec"),
+        "zig" => Some("zig"),
+        "nim" => Some("nim"),
+        "v" => Some("v"),
+        "groovy" => Some("groovy"),
+        "ps1" => Some("powershell"),
+        "bat" | "cmd" => Some("batch"),
+        _ => None,
+    }
+}
+
+const SUPPORTED_EXTENSIONS: &[&str] = &[
+    "c", "h", "cpp", "cc", "cxx", "hpp", "hxx", "hh", "py", "pyw", "js", "mjs", "cjs", "jsx", "ts",
+    "mts", "cts", "tsx", "rs", "go", "java", "kt", "kts", "rb", "swift", "cs", "php", "sh", "bash",
+    "zsh", "fish", "pl", "pm", "lua", "r", "scala", "dart", "ex", "exs", "erl", "hs", "ml", "mli",
+    "sql", "m", "mm", "zig", "nim", "v", "groovy", "ps1", "bat", "cmd",
+];
+
+impl Converter for CodeConverter {
+    fn supported_extensions(&self) -> &[&str] {
+        SUPPORTED_EXTENSIONS
+    }
+
+    fn convert(
+        &self,
+        data: &[u8],
+        _options: &ConversionOptions,
+    ) -> Result<ConversionResult, ConvertError> {
+        self.convert_with_extension(data, "code", _options)
+    }
+}
+
+impl CodeConverter {
+    /// Convert with a known file extension to produce the correct language tag.
+    pub fn convert_with_extension(
+        &self,
+        data: &[u8],
+        extension: &str,
+        _options: &ConversionOptions,
+    ) -> Result<ConversionResult, ConvertError> {
+        let (text, warning) = super::decode_text(data);
+        let mut warnings = Vec::new();
+        if let Some(w) = warning {
+            warnings.push(w);
+        }
+
+        let language = language_for_extension(extension).unwrap_or("code");
+        let content = text.trim_end();
+        let markdown = format!("```{language}\n{content}\n```\n");
+
+        Ok(ConversionResult {
+            markdown,
+            warnings,
+            ..Default::default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_code_python_fenced_block() {
+        let converter = CodeConverter;
+        let input = b"def hello():\n    print('Hello, world!')\n";
+        let result = converter
+            .convert_with_extension(input, "py", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.starts_with("```python\n"));
+        assert!(result.markdown.ends_with("\n```\n"));
+        assert!(result.markdown.contains("def hello():"));
+    }
+
+    #[test]
+    fn test_code_c_fenced_block() {
+        let converter = CodeConverter;
+        let input = b"#include <stdio.h>\nint main() { return 0; }\n";
+        let result = converter
+            .convert_with_extension(input, "c", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.starts_with("```c\n"));
+        assert!(result.markdown.contains("#include <stdio.h>"));
+    }
+
+    #[test]
+    fn test_code_javascript_fenced_block() {
+        let converter = CodeConverter;
+        let input = b"console.log('hello');\n";
+        let result = converter
+            .convert_with_extension(input, "js", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.starts_with("```javascript\n"));
+        assert!(result.markdown.contains("console.log"));
+    }
+
+    #[test]
+    fn test_code_empty_input() {
+        let converter = CodeConverter;
+        let result = converter
+            .convert_with_extension(b"", "py", &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "```python\n\n```\n");
+        // Whitespace-only input also produces empty code block
+        let result = converter
+            .convert_with_extension(b"  \n\n", "py", &ConversionOptions::default())
+            .unwrap();
+        assert_eq!(result.markdown, "```python\n\n```\n");
+    }
+
+    #[test]
+    fn test_code_unicode_cjk() {
+        let converter = CodeConverter;
+        let input = "# 한국어 주석\nprint('中文')\n".as_bytes();
+        let result = converter
+            .convert_with_extension(input, "py", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("한국어"));
+        assert!(result.markdown.contains("中文"));
+    }
+
+    #[test]
+    fn test_code_emoji() {
+        let converter = CodeConverter;
+        let input = "msg = '🚀✨🌍'\n".as_bytes();
+        let result = converter
+            .convert_with_extension(input, "py", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("🚀✨🌍"));
+    }
+
+    #[test]
+    fn test_code_non_utf8_decoded_with_warning() {
+        let converter = CodeConverter;
+        // Windows-1252 encoded: "café" with é = 0xE9
+        let input = b"caf\xe9";
+        let result = converter
+            .convert_with_extension(input, "py", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("café"));
+        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(
+            result.warnings[0].code,
+            crate::converter::WarningCode::UnsupportedFeature
+        );
+    }
+
+    #[test]
+    fn test_code_supported_extensions() {
+        let converter = CodeConverter;
+        let exts = converter.supported_extensions();
+        assert!(exts.contains(&"py"));
+        assert!(exts.contains(&"rs"));
+        assert!(exts.contains(&"js"));
+        assert!(exts.contains(&"c"));
+        assert!(exts.contains(&"go"));
+        assert!(exts.contains(&"java"));
+        assert!(exts.contains(&"sh"));
+        assert!(exts.contains(&"sql"));
+        assert!(exts.contains(&"zig"));
+        assert!(exts.contains(&"bat"));
+        assert!(!exts.contains(&"txt"));
+        assert!(!exts.contains(&"docx"));
+    }
+
+    #[test]
+    fn test_code_can_convert() {
+        let converter = CodeConverter;
+        assert!(converter.can_convert("py", &[]));
+        assert!(converter.can_convert("rs", &[]));
+        assert!(converter.can_convert("js", &[]));
+        assert!(!converter.can_convert("txt", &[]));
+        assert!(!converter.can_convert("docx", &[]));
+        assert!(!converter.can_convert("json", &[]));
+    }
+
+    #[test]
+    fn test_code_no_title_or_images() {
+        let converter = CodeConverter;
+        let result = converter
+            .convert_with_extension(b"x = 1", "py", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.title.is_none());
+        assert!(result.images.is_empty());
+        assert!(result.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_code_header_extension_mapping() {
+        let converter = CodeConverter;
+
+        let result = converter
+            .convert_with_extension(b"int x;", "h", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.starts_with("```c\n"));
+
+        let result = converter
+            .convert_with_extension(b"int x;", "hpp", &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.starts_with("```cpp\n"));
+    }
+
+    #[test]
+    fn test_code_backtick_content_not_broken() {
+        let converter = CodeConverter;
+        let input = b"code = '''```triple backticks```'''\n";
+        let result = converter
+            .convert_with_extension(input, "py", &ConversionOptions::default())
+            .unwrap();
+        // The fenced block structure should remain valid —
+        // content with backticks is preserved as-is
+        assert!(result.markdown.starts_with("```python\n"));
+        assert!(result.markdown.contains("```triple backticks```"));
+        assert!(result.markdown.ends_with("\n```\n"));
+    }
+}

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -1,3 +1,4 @@
+pub mod code;
 pub mod csv;
 pub mod docx;
 pub mod gemini;

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -80,6 +80,11 @@ fn detect_by_extension(path: &Path) -> Option<&'static str> {
         | "yaml" | "yml" => Some("txt"),
         "png" | "jpg" | "jpeg" | "gif" | "webp" | "bmp" | "tiff" | "tif" | "svg" | "heic"
         | "heif" | "avif" => Some("image"),
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hxx" | "hh" | "py" | "pyw" | "js" | "mjs"
+        | "cjs" | "jsx" | "ts" | "mts" | "cts" | "tsx" | "rs" | "go" | "java" | "kt" | "kts"
+        | "rb" | "swift" | "cs" | "php" | "sh" | "bash" | "zsh" | "fish" | "pl" | "pm" | "lua"
+        | "r" | "scala" | "dart" | "ex" | "exs" | "erl" | "hs" | "ml" | "mli" | "sql" | "m"
+        | "mm" | "zig" | "nim" | "v" | "groovy" | "ps1" | "bat" | "cmd" => Some("code"),
         _ => None,
     }
 }
@@ -251,6 +256,26 @@ mod tests {
                 detect_format(&path, &[]),
                 Some("image"),
                 "expected 'image' for .{}",
+                ext
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_format_code_variants() {
+        let code_extensions = [
+            "c", "h", "cpp", "cc", "cxx", "hpp", "hxx", "hh", "py", "pyw", "js", "mjs", "cjs",
+            "jsx", "ts", "mts", "cts", "tsx", "rs", "go", "java", "kt", "kts", "rb", "swift", "cs",
+            "php", "sh", "bash", "zsh", "fish", "pl", "pm", "lua", "r", "scala", "dart", "ex",
+            "exs", "erl", "hs", "ml", "mli", "sql", "m", "mm", "zig", "nim", "v", "groovy", "ps1",
+            "bat", "cmd",
+        ];
+        for ext in &code_extensions {
+            let path = PathBuf::from(format!("file.{}", ext));
+            assert_eq!(
+                detect_format(&path, &[]),
+                Some("code"),
+                "expected 'code' for .{}",
                 ext
             );
         }

--- a/tests/fixtures/expected/sample.py.md
+++ b/tests/fixtures/expected/sample.py.md
@@ -1,0 +1,25 @@
+```python
+# Sample Python file for testing CodeConverter
+# 한국어 주석 (Korean comment)
+
+
+class Greeter:
+    """A simple greeter class."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def greet(self) -> str:
+        return f"Hello, {self.name}! 🚀"
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+if __name__ == "__main__":
+    g = Greeter("世界")
+    print(g.greet())
+    print(add(1, 2))
+```

--- a/tests/fixtures/sample.py
+++ b/tests/fixtures/sample.py
@@ -1,0 +1,23 @@
+# Sample Python file for testing CodeConverter
+# 한국어 주석 (Korean comment)
+
+
+class Greeter:
+    """A simple greeter class."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def greet(self) -> str:
+        return f"Hello, {self.name}! 🚀"
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+
+
+if __name__ == "__main__":
+    g = Greeter("世界")
+    print(g.greet())
+    print(add(1, 2))

--- a/tests/test_code.rs
+++ b/tests/test_code.rs
@@ -1,0 +1,35 @@
+mod common;
+
+use anytomd::{ConversionOptions, convert_bytes, convert_file};
+use common::normalize;
+
+/// Integration test: sample.py end-to-end conversion via convert_file.
+#[test]
+fn test_code_convert_file_sample() {
+    let result = convert_file("tests/fixtures/sample.py", &ConversionOptions::default()).unwrap();
+    assert!(result.markdown.starts_with("```python\n"));
+    assert!(result.markdown.ends_with("\n```\n"));
+    assert!(result.markdown.contains("class Greeter:"));
+    assert!(result.markdown.contains("def add("));
+    assert!(result.markdown.contains("한국어"));
+    assert!(result.markdown.contains("🚀"));
+    assert!(result.markdown.contains("世界"));
+}
+
+/// Golden test: compare normalized output against expected file.
+#[test]
+fn test_code_golden_sample() {
+    let result = convert_file("tests/fixtures/sample.py", &ConversionOptions::default()).unwrap();
+    let expected = include_str!("fixtures/expected/sample.py.md");
+    assert_eq!(normalize(&result.markdown), normalize(expected));
+}
+
+/// Integration test: convert_bytes with explicit extension.
+#[test]
+fn test_code_convert_bytes_direct() {
+    let input = b"fn main() {\n    println!(\"hello\");\n}\n";
+    let result = convert_bytes(input, "rs", &ConversionOptions::default()).unwrap();
+    assert!(result.markdown.starts_with("```rust\n"));
+    assert!(result.markdown.ends_with("\n```\n"));
+    assert!(result.markdown.contains("fn main()"));
+}


### PR DESCRIPTION
## Summary

- Add `CodeConverter` that wraps source code files in fenced code blocks with language identifiers (e.g., ` ```python `, ` ```rust `) for better LLM consumption
- Support 50+ file extensions across C/C++, Python, JavaScript/TypeScript, Rust, Go, Java, Ruby, Swift, shell scripts, and many more
- Add code extension detection in `detection.rs` to prevent JSON heuristic false positives for code files starting with `{` or `[`

## Key changes

| File | Change |
|------|--------|
| `src/converter/code.rs` | New `CodeConverter` with extension→language mapping, 12 unit tests |
| `src/converter/mod.rs` | Register `pub mod code` |
| `src/detection.rs` | Map code extensions to `"code"` format + detection test |
| `src/lib.rs` | Dispatch `CodeConverter` before generic loop (needs extension for language tag); pass through original extension when detection returns `"code"` |
| `tests/test_code.rs` | 3 integration tests (file, golden, bytes API) |
| `tests/fixtures/sample.py` | Python fixture with class, CJK comments, emoji |
| `tests/fixtures/expected/sample.py.md` | Golden output |
| `README.md` | Add Code row to Supported Formats table |

## Design note

`CodeConverter` is dispatched before the generic converter loop because the `Converter` trait's `convert()` method doesn't receive the file extension, which is needed for language detection. The `convert_with_extension()` method is called directly instead.

## Test plan

- [x] All 352 unit tests pass
- [x] All integration tests pass (including new `test_code.rs`)
- [x] Golden test matches expected output
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)