### PR TITLE
fix: patch reproduced conversion bugs across strict mode, OOXML, and JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Agent Instructions
+
+- Before doing any work in this repository, read [`CLAUDE.md`](./CLAUDE.md) first.

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -978,6 +978,7 @@ fn parse_document(
                                     placeholder: placeholder.clone(),
                                     original_alt,
                                     filename: filename.clone(),
+                                    bytes_key: rel_id.clone(),
                                 });
                                 let img_md = format!("![{placeholder}]({filename})");
                                 let seg = RunSegment {
@@ -1208,7 +1209,7 @@ impl DocxConverter {
         let mut image_bytes_map: HashMap<String, Vec<u8>> = HashMap::new();
         if need_image_bytes {
             let mut total_image_bytes: usize = 0;
-            for rel in relationships.values() {
+            for (rel_id, rel) in &relationships {
                 if !rel.rel_type.contains("image") {
                     continue;
                 }
@@ -1228,7 +1229,7 @@ impl DocxConverter {
                         if options.extract_images {
                             images.push((filename.clone(), img_data.clone()));
                         }
-                        image_bytes_map.insert(filename, img_data);
+                        image_bytes_map.insert(rel_id.clone(), img_data);
                     } else {
                         warnings.push(ConversionWarning {
                             code: WarningCode::ResourceLimitReached,
@@ -2427,6 +2428,44 @@ mod tests {
             count, 2,
             "expected 2 described images, found {} in: {}",
             count, md
+        );
+    }
+
+    #[test]
+    fn test_docx_duplicate_basenames_different_paths_independent_descriptions() {
+        let body = format!(
+            "{}{}{}",
+            r#"<w:p><w:r><w:drawing><wp:inline><wp:docPr descr="First image"/><a:graphic><a:graphicData><pic:pic><pic:blipFill><a:blip r:embed="rId2"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#,
+            para("Text between images"),
+            r#"<w:p><w:r><w:drawing><wp:inline><wp:docPr descr="Second image"/><a:graphic><a:graphicData><pic:pic><pic:blipFill><a:blip r:embed="rId3"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#,
+        );
+        let doc = wrap_body(&body);
+        let rels = r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/a/image1.png"/><Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/b/image1.png"/></Relationships>"#;
+        let data = build_test_docx_with_images(
+            &doc,
+            rels,
+            &[
+                ("word/media/a/image1.png", b"fake-cat-png-data"),
+                ("word/media/b/image1.png", b"fake-dog-png-data"),
+            ],
+        );
+
+        let converter = DocxConverter;
+        let options = ConversionOptions {
+            image_describer: Some(Arc::new(MockDescriberByContent)),
+            ..Default::default()
+        };
+        let result = converter.convert(&data, &options).unwrap();
+        let md = &result.markdown;
+        assert!(
+            md.contains("![A photo of a cat](image1.png)"),
+            "expected cat description, markdown was: {}",
+            md
+        );
+        assert!(
+            md.contains("![A photo of a dog](image1.png)"),
+            "expected dog description, markdown was: {}",
+            md
         );
     }
 

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -2342,6 +2342,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_docx_image_describer_dot_slash_target_path() {
+        let body = r#"<w:p><w:r><w:drawing><wp:inline><wp:docPr descr="Original alt"/><a:graphic><a:graphicData><pic:pic><pic:blipFill><a:blip r:embed="rId2"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#;
+        let doc = wrap_body(body);
+        let rels = r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="./media/image1.png"/></Relationships>"#;
+        let fake_png = b"fake-png-data";
+        let data = build_test_docx_with_image(&doc, rels, "word/media/image1.png", fake_png);
+
+        let converter = DocxConverter;
+        let options = ConversionOptions {
+            image_describer: Some(Arc::new(MockDescriber {
+                description: "Described image".to_string(),
+            })),
+            ..Default::default()
+        };
+        let result = converter.convert(&data, &options).unwrap();
+        assert!(
+            result.markdown.contains("![Described image](image1.png)"),
+            "markdown was: {}",
+            result.markdown
+        );
+    }
+
     /// Helper: build a DOCX with multiple embedded image files.
     fn build_test_docx_with_images(
         document_xml: &str,

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -15,7 +15,7 @@ use zip::ZipArchive;
 
 use crate::converter::ooxml_utils::{
     ImageInfo, PendingImageResolution, Relationship, parse_relationships,
-    resolve_image_placeholders,
+    resolve_image_placeholders, resolve_relative_to_file,
 };
 use crate::converter::{
     ConversionOptions, ConversionResult, ConversionWarning, Converter, WarningCode,
@@ -1216,15 +1216,14 @@ impl DocxConverter {
                 if total_image_bytes >= options.max_total_image_bytes {
                     break;
                 }
-                let image_path = format!("word/{}", rel.target);
+                let image_path = resolve_relative_to_file("word/document.xml", &rel.target);
                 if let Ok(Some(img_data)) = read_zip_bytes(&mut archive, &image_path) {
                     total_image_bytes += img_data.len();
                     if total_image_bytes <= options.max_total_image_bytes {
-                        let filename = rel
-                            .target
+                        let filename = image_path
                             .rsplit('/')
                             .next()
-                            .unwrap_or(&rel.target)
+                            .unwrap_or(&image_path)
                             .to_string();
                         if options.extract_images {
                             images.push((filename.clone(), img_data.clone()));
@@ -2318,6 +2317,29 @@ mod tests {
         let result = converter.convert(&data, &options).unwrap();
         assert!(result.markdown.contains("![Described image](image1.png)"));
         assert!(!result.images.is_empty());
+    }
+
+    #[test]
+    fn test_docx_image_describer_absolute_target_path() {
+        let body = r#"<w:p><w:r><w:drawing><wp:inline><wp:docPr descr="Original alt"/><a:graphic><a:graphicData><pic:pic><pic:blipFill><a:blip r:embed="rId2"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>"#;
+        let doc = wrap_body(body);
+        let rels = r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="/word/media/image1.png"/></Relationships>"#;
+        let fake_png = b"fake-png-data";
+        let data = build_test_docx_with_image(&doc, rels, "word/media/image1.png", fake_png);
+
+        let converter = DocxConverter;
+        let options = ConversionOptions {
+            image_describer: Some(Arc::new(MockDescriber {
+                description: "Described image".to_string(),
+            })),
+            ..Default::default()
+        };
+        let result = converter.convert(&data, &options).unwrap();
+        assert!(
+            result.markdown.contains("![Described image](image1.png)"),
+            "markdown was: {}",
+            result.markdown
+        );
     }
 
     /// Helper: build a DOCX with multiple embedded image files.

--- a/src/converter/image.rs
+++ b/src/converter/image.rs
@@ -84,13 +84,14 @@ impl ImageConverter {
         let plain_text = format!("{placeholder}\n");
 
         let image_infos = vec![ImageInfo {
-            placeholder,
+            placeholder: placeholder.clone(),
             original_alt: String::new(),
             filename: filename.clone(),
+            bytes_key: placeholder.clone(),
         }];
 
         let mut image_bytes_map = HashMap::new();
-        image_bytes_map.insert(filename.clone(), data.to_vec());
+        image_bytes_map.insert(placeholder.clone(), data.to_vec());
 
         // Extract image data if requested
         let images = if options.extract_images {

--- a/src/converter/json.rs
+++ b/src/converter/json.rs
@@ -18,10 +18,7 @@ impl Converter for JsonConverter {
         data: &[u8],
         _options: &ConversionOptions,
     ) -> Result<ConversionResult, ConvertError> {
-        let mut text = String::from_utf8(data.to_vec())?;
-        if let Some(stripped) = text.strip_prefix('\u{feff}') {
-            text = stripped.to_string();
-        }
+        let (text, encoding_warning) = super::decode_text(data);
 
         // Parse and re-serialize for pretty-printing
         let value: serde_json::Value =
@@ -36,10 +33,15 @@ impl Converter for JsonConverter {
 
         let markdown = format!("```json\n{pretty}\n```\n");
         let plain_text = format!("{pretty}\n");
+        let mut warnings = Vec::new();
+        if let Some(w) = encoding_warning {
+            warnings.push(w);
+        }
 
         Ok(ConversionResult {
             markdown,
             plain_text,
+            warnings,
             ..Default::default()
         })
     }
@@ -217,5 +219,19 @@ mod tests {
             .unwrap();
         assert!(result.markdown.contains("\"k\""));
         assert!(result.markdown.contains("1"));
+    }
+
+    #[test]
+    fn test_json_utf16_le_bom_is_accepted_with_warning() {
+        let converter = JsonConverter;
+        let mut input = vec![0xFF, 0xFE];
+        for code_unit in "{\"k\":1}".encode_utf16() {
+            input.extend_from_slice(&code_unit.to_le_bytes());
+        }
+        let result = converter
+            .convert(&input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("\"k\""));
+        assert!(!result.warnings.is_empty(), "expected encoding warning");
     }
 }

--- a/src/converter/json.rs
+++ b/src/converter/json.rs
@@ -18,7 +18,10 @@ impl Converter for JsonConverter {
         data: &[u8],
         _options: &ConversionOptions,
     ) -> Result<ConversionResult, ConvertError> {
-        let text = String::from_utf8(data.to_vec())?;
+        let mut text = String::from_utf8(data.to_vec())?;
+        if let Some(stripped) = text.strip_prefix('\u{feff}') {
+            text = stripped.to_string();
+        }
 
         // Parse and re-serialize for pretty-printing
         let value: serde_json::Value =
@@ -202,5 +205,17 @@ mod tests {
         let input = vec![0xFF, 0xFE];
         let result = converter.convert(&input, &ConversionOptions::default());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_json_utf8_bom_is_accepted() {
+        let converter = JsonConverter;
+        let mut input = vec![0xEF, 0xBB, 0xBF];
+        input.extend_from_slice(br#"{"k":1}"#);
+        let result = converter
+            .convert(&input, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("\"k\""));
+        assert!(result.markdown.contains("1"));
     }
 }

--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -100,9 +100,7 @@ pub(crate) fn derive_rels_path(file_path: &str) -> String {
 /// Example: base_dir=`xl/drawings`, target=`../media/image1.png`
 ///          -> `xl/media/image1.png`
 pub(crate) fn resolve_relative_path(base_dir: &str, target: &str) -> String {
-    let joined = if target.starts_with('/') {
-        target.to_string()
-    } else if base_dir.is_empty() {
+    let joined = if target.starts_with('/') || base_dir.is_empty() {
         target.to_string()
     } else {
         format!("{base_dir}/{target}")
@@ -122,9 +120,7 @@ pub(crate) fn resolve_relative_to_file(base_file: &str, target: &str) -> String 
         .rfind('/')
         .map(|pos| &base_file[..pos])
         .unwrap_or("");
-    let joined = if target.starts_with('/') {
-        target.to_string()
-    } else if base_dir.is_empty() {
+    let joined = if target.starts_with('/') || base_dir.is_empty() {
         target.to_string()
     } else {
         format!("{base_dir}/{target}")

--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -20,6 +20,9 @@ pub(crate) struct ImageInfo {
     pub(crate) placeholder: String,
     pub(crate) original_alt: String,
     pub(crate) filename: String,
+    /// Lookup key for image bytes in `PendingImageResolution::bytes`.
+    /// This can differ from `filename` when multiple images share a basename.
+    pub(crate) bytes_key: String,
 }
 
 /// Collected image data from a converter's parse phase, ready for resolution.
@@ -29,6 +32,7 @@ pub(crate) struct ImageInfo {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PendingImageResolution {
     pub(crate) infos: Vec<ImageInfo>,
+    /// Raw image bytes keyed by `ImageInfo::bytes_key`.
     pub(crate) bytes: HashMap<String, Vec<u8>>,
 }
 
@@ -50,7 +54,12 @@ pub(crate) fn parse_relationships(xml: &str) -> HashMap<String, Relationship> {
 
                     for attr in e.attributes().flatten() {
                         let key = std::str::from_utf8(attr.key.as_ref()).unwrap_or("");
-                        let val = String::from_utf8_lossy(&attr.value).to_string();
+                        let val = attr
+                            .decode_and_unescape_value(reader.decoder())
+                            .map(|v| v.into_owned())
+                            .unwrap_or_else(|_| {
+                                String::from_utf8_lossy(attr.value.as_ref()).to_string()
+                            });
                         match key {
                             "Id" => id = Some(val),
                             "Target" => target = Some(val),
@@ -123,8 +132,12 @@ pub(crate) fn resolve_relative_path(base_dir: &str, target: &str) -> String {
 /// Example: base_file=`ppt/slides/slide1.xml`, target=`../media/image1.png`
 ///          -> `ppt/media/image1.png`
 pub(crate) fn resolve_relative_to_file(base_file: &str, target: &str) -> String {
+    if let Some(stripped) = target.strip_prefix('/') {
+        return stripped.to_string();
+    }
+
     if !target.starts_with("../") {
-        // Absolute or same-directory target
+        // Same-directory target
         if let Some(pos) = base_file.rfind('/') {
             return format!("{}/{target}", &base_file[..pos]);
         }
@@ -163,7 +176,10 @@ pub(crate) fn resolve_image_placeholders(
 ) {
     if let Some(describer) = describer {
         for info in image_infos {
-            if let Some(img_data) = image_bytes.get(&info.filename) {
+            if let Some(img_data) = image_bytes
+                .get(&info.bytes_key)
+                .or_else(|| image_bytes.get(&info.filename))
+            {
                 let mime = crate::converter::mime_from_image(&info.filename, img_data);
                 let prompt = "Describe this image concisely for use as alt text.";
                 match describer.describe(img_data, mime, prompt) {
@@ -239,7 +255,9 @@ pub(crate) async fn resolve_image_placeholders_async(
     let futures: Vec<_> = image_infos
         .iter()
         .map(|info| {
-            let bytes_opt = image_bytes.get(&info.filename);
+            let bytes_opt = image_bytes
+                .get(&info.bytes_key)
+                .or_else(|| image_bytes.get(&info.filename));
             async move {
                 if let Some(img_data) = bytes_opt {
                     let mime = crate::converter::mime_from_image(&info.filename, img_data);
@@ -301,6 +319,14 @@ mod tests {
         let r2 = rels.get("rId2").unwrap();
         assert_eq!(r2.target, "https://example.com");
         assert!(r2.rel_type.contains("hyperlink"));
+    }
+
+    #[test]
+    fn test_parse_relationships_unescapes_target_entities() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com?a=1&amp;b=2" TargetMode="External"/></Relationships>"#;
+        let rels = parse_relationships(xml);
+        let r1 = rels.get("rId1").expect("missing rId1");
+        assert_eq!(r1.target, "https://example.com?a=1&b=2");
     }
 
     #[test]
@@ -387,6 +413,14 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_relative_to_file_absolute_path() {
+        assert_eq!(
+            resolve_relative_to_file("ppt/slides/slide1.xml", "/ppt/media/image1.png"),
+            "ppt/media/image1.png"
+        );
+    }
+
+    #[test]
     fn test_resolve_relative_path_excessive_parent_stops_at_root() {
         // base "a" has 1 segment. "../../etc/passwd" tries 2 levels up.
         // First "../" pops "a"; second "../" finds empty vec and breaks.
@@ -425,11 +459,13 @@ mod tests {
                 placeholder: "__img_0__".to_string(),
                 original_alt: "A cat".to_string(),
                 filename: "cat.png".to_string(),
+                bytes_key: "__img_0__".to_string(),
             },
             ImageInfo {
                 placeholder: "__img_1__".to_string(),
                 original_alt: "A dog".to_string(),
                 filename: "dog.png".to_string(),
+                bytes_key: "__img_1__".to_string(),
             },
         ];
         let image_bytes = HashMap::new();
@@ -466,6 +502,7 @@ mod tests {
             placeholder: "__img_0__".to_string(),
             original_alt: "A cat".to_string(),
             filename: "cat.png".to_string(),
+            bytes_key: "__img_0__".to_string(),
         }];
         let mut image_bytes = HashMap::new();
         image_bytes.insert("cat.png".to_string(), vec![0x89, b'P', b'N', b'G']);
@@ -509,6 +546,7 @@ mod tests {
             placeholder: "__img_0__".to_string(),
             original_alt: "A cat".to_string(),
             filename: "cat.png".to_string(),
+            bytes_key: "__img_0__".to_string(),
         }];
         let mut image_bytes = HashMap::new();
         image_bytes.insert("cat.png".to_string(), vec![0x89, b'P', b'N', b'G']);
@@ -526,6 +564,66 @@ mod tests {
         assert_eq!(pt, "A cat");
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("image description failed"));
+    }
+
+    #[test]
+    fn test_resolve_image_placeholders_bytes_key_disambiguates_same_filename() {
+        use crate::converter::ImageDescriber;
+        use crate::error::ConvertError;
+
+        struct ByteKeyDescriber;
+        impl ImageDescriber for ByteKeyDescriber {
+            fn describe(
+                &self,
+                image_bytes: &[u8],
+                _mime_type: &str,
+                _prompt: &str,
+            ) -> Result<String, ConvertError> {
+                match image_bytes.first().copied() {
+                    Some(b'A') => Ok("DESC_A".to_string()),
+                    Some(b'B') => Ok("DESC_B".to_string()),
+                    _ => Ok("DESC_UNKNOWN".to_string()),
+                }
+            }
+        }
+
+        let mut md = "![__img_0__](image1.png)\n![__img_1__](image1.png)".to_string();
+        let mut pt = "__img_0__\n__img_1__".to_string();
+        let infos = vec![
+            ImageInfo {
+                placeholder: "__img_0__".to_string(),
+                original_alt: "".to_string(),
+                filename: "image1.png".to_string(),
+                bytes_key: "k1".to_string(),
+            },
+            ImageInfo {
+                placeholder: "__img_1__".to_string(),
+                original_alt: "".to_string(),
+                filename: "image1.png".to_string(),
+                bytes_key: "k2".to_string(),
+            },
+        ];
+
+        let mut image_bytes = HashMap::new();
+        image_bytes.insert("k1".to_string(), b"A-image".to_vec());
+        image_bytes.insert("k2".to_string(), b"B-image".to_vec());
+
+        let mut warnings = Vec::new();
+        let describer = ByteKeyDescriber;
+        resolve_image_placeholders(
+            &mut md,
+            &mut pt,
+            &infos,
+            &image_bytes,
+            Some(&describer),
+            &mut warnings,
+        );
+
+        assert!(md.contains("![DESC_A](image1.png)"));
+        assert!(md.contains("![DESC_B](image1.png)"));
+        assert!(pt.contains("DESC_A"));
+        assert!(pt.contains("DESC_B"));
+        assert!(warnings.is_empty());
     }
 
     // ---- Async resolve tests (require tokio dev-dependency) ----
@@ -577,11 +675,13 @@ mod tests {
                     placeholder: "__img_0__".to_string(),
                     original_alt: "A cat".to_string(),
                     filename: "cat.png".to_string(),
+                    bytes_key: "__img_0__".to_string(),
                 },
                 ImageInfo {
                     placeholder: "__img_1__".to_string(),
                     original_alt: "A dog".to_string(),
                     filename: "dog.png".to_string(),
+                    bytes_key: "__img_1__".to_string(),
                 },
             ];
             let mut image_bytes = HashMap::new();
@@ -613,6 +713,7 @@ mod tests {
                 placeholder: "__img_0__".to_string(),
                 original_alt: "A cat".to_string(),
                 filename: "cat.png".to_string(),
+                bytes_key: "__img_0__".to_string(),
             }];
             let mut image_bytes = HashMap::new();
             image_bytes.insert("cat.png".to_string(), vec![0x89, b'P', b'N', b'G']);
@@ -641,6 +742,7 @@ mod tests {
                 placeholder: "__img_0__".to_string(),
                 original_alt: "A cat".to_string(),
                 filename: "cat.png".to_string(),
+                bytes_key: "__img_0__".to_string(),
             }];
             let image_bytes = HashMap::new(); // no bytes
             let mut warnings = Vec::new();

--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -100,28 +100,14 @@ pub(crate) fn derive_rels_path(file_path: &str) -> String {
 /// Example: base_dir=`xl/drawings`, target=`../media/image1.png`
 ///          -> `xl/media/image1.png`
 pub(crate) fn resolve_relative_path(base_dir: &str, target: &str) -> String {
-    if !target.starts_with("../") {
-        if base_dir.is_empty() {
-            return target.to_string();
-        }
-        return format!("{base_dir}/{target}");
-    }
-
-    let mut parts: Vec<&str> = base_dir.split('/').collect();
-
-    let mut remaining = target;
-    while let Some(rest) = remaining.strip_prefix("../") {
-        if parts.pop().is_none() {
-            break;
-        }
-        remaining = rest;
-    }
-
-    if parts.is_empty() {
-        remaining.to_string()
+    let joined = if target.starts_with('/') {
+        target.to_string()
+    } else if base_dir.is_empty() {
+        target.to_string()
     } else {
-        format!("{}/{remaining}", parts.join("/"))
-    }
+        format!("{base_dir}/{target}")
+    };
+    normalize_package_path(&joined)
 }
 
 /// Resolve a relative path target against a base file path.
@@ -132,36 +118,33 @@ pub(crate) fn resolve_relative_path(base_dir: &str, target: &str) -> String {
 /// Example: base_file=`ppt/slides/slide1.xml`, target=`../media/image1.png`
 ///          -> `ppt/media/image1.png`
 pub(crate) fn resolve_relative_to_file(base_file: &str, target: &str) -> String {
-    if let Some(stripped) = target.strip_prefix('/') {
-        return stripped.to_string();
-    }
-
-    if !target.starts_with("../") {
-        // Same-directory target
-        if let Some(pos) = base_file.rfind('/') {
-            return format!("{}/{target}", &base_file[..pos]);
-        }
-        return target.to_string();
-    }
-
-    // Walk up for each "../" prefix
-    let mut base_parts: Vec<&str> = base_file.split('/').collect();
-    // Remove the filename from base
-    base_parts.pop();
-
-    let mut target_remaining = target;
-    while let Some(rest) = target_remaining.strip_prefix("../") {
-        if base_parts.pop().is_none() {
-            break;
-        }
-        target_remaining = rest;
-    }
-
-    if base_parts.is_empty() {
-        target_remaining.to_string()
+    let base_dir = base_file
+        .rfind('/')
+        .map(|pos| &base_file[..pos])
+        .unwrap_or("");
+    let joined = if target.starts_with('/') {
+        target.to_string()
+    } else if base_dir.is_empty() {
+        target.to_string()
     } else {
-        format!("{}/{target_remaining}", base_parts.join("/"))
+        format!("{base_dir}/{target}")
+    };
+    normalize_package_path(&joined)
+}
+
+fn normalize_package_path(path: &str) -> String {
+    let mut out: Vec<&str> = Vec::new();
+    for part in path.split('/') {
+        if part.is_empty() || part == "." {
+            continue;
+        }
+        if part == ".." {
+            let _ = out.pop();
+            continue;
+        }
+        out.push(part);
     }
+    out.join("/")
 }
 
 /// Replace image placeholders in markdown and plain text with descriptions
@@ -384,6 +367,14 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_relative_path_current_dir_segment() {
+        assert_eq!(
+            resolve_relative_path("xl/drawings", "./media/image1.png"),
+            "xl/drawings/media/image1.png"
+        );
+    }
+
+    #[test]
     fn test_resolve_relative_path_empty_base() {
         assert_eq!(resolve_relative_path("", "image1.png"), "image1.png");
     }
@@ -401,6 +392,14 @@ mod tests {
         assert_eq!(
             resolve_relative_to_file("ppt/slides/slide1.xml", "../media/image1.png"),
             "ppt/media/image1.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_relative_to_file_current_dir_segment() {
+        assert_eq!(
+            resolve_relative_to_file("word/document.xml", "./media/image1.png"),
+            "word/media/image1.png"
         );
     }
 
@@ -423,21 +422,17 @@ mod tests {
     #[test]
     fn test_resolve_relative_path_excessive_parent_stops_at_root() {
         // base "a" has 1 segment. "../../etc/passwd" tries 2 levels up.
-        // First "../" pops "a"; second "../" finds empty vec and breaks.
-        // The unresolved "../etc/passwd" remains as-is.
-        assert_eq!(
-            resolve_relative_path("a", "../../etc/passwd"),
-            "../etc/passwd"
-        );
+        // After reaching root, extra "../" are clamped.
+        assert_eq!(resolve_relative_path("a", "../../etc/passwd"), "etc/passwd");
     }
 
     #[test]
     fn test_resolve_relative_to_file_excessive_parent_stops_at_root() {
         // base_file "a/b.xml" → directory segments: ["a"].
-        // First "../" pops "a"; second "../" finds empty vec and breaks.
+        // After reaching root, extra "../" are clamped.
         assert_eq!(
             resolve_relative_to_file("a/b.xml", "../../etc/passwd"),
-            "../etc/passwd"
+            "etc/passwd"
         );
     }
 

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -740,6 +740,7 @@ fn render_slide(
     shapes: &[ShapeContent],
     notes: &Option<String>,
     image_filenames: &HashMap<String, String>,
+    slide_key: &str,
     image_counter: &mut usize,
 ) -> (String, String, Vec<ImageInfo>) {
     let mut out = String::new();
@@ -794,6 +795,7 @@ fn render_slide(
                         placeholder: placeholder.clone(),
                         original_alt: original_alt.clone(),
                         filename: filename.clone(),
+                        bytes_key: format!("{slide_key}::{rel_id}"),
                     });
                     out.push_str(&format!("![{placeholder}]({filename})\n\n"));
                     // Plain text: image description placeholder (resolved later)
@@ -939,7 +941,8 @@ impl PptxConverter {
                             if options.extract_images {
                                 images.push((filename.to_string(), img_data.clone()));
                             }
-                            all_image_bytes.insert(filename.to_string(), img_data);
+                            let bytes_key = format!("{}::{}", slide_info.path, rel_id);
+                            all_image_bytes.insert(bytes_key, img_data);
                         } else {
                             warnings.push(ConversionWarning {
                                 code: WarningCode::ResourceLimitReached,
@@ -970,6 +973,7 @@ impl PptxConverter {
                 &shapes,
                 &notes,
                 &image_filenames,
+                &slide_info.path,
                 &mut image_counter,
             );
 
@@ -1630,6 +1634,10 @@ mod tests {
     fn test_pptx_resolve_relative_to_file() {
         assert_eq!(
             resolve_relative_to_file("ppt/slides/slide1.xml", "../media/image1.png"),
+            "ppt/media/image1.png"
+        );
+        assert_eq!(
+            resolve_relative_to_file("ppt/slides/slide1.xml", "/ppt/media/image1.png"),
             "ppt/media/image1.png"
         );
         assert_eq!(

--- a/src/converter/xlsx.rs
+++ b/src/converter/xlsx.rs
@@ -349,18 +349,20 @@ impl XlsxConverter {
                     total_image_bytes += img_data.len();
                     if total_image_bytes <= options.max_total_image_bytes {
                         let placeholder = format!("__img_{n}__", n = image_counter);
+                        let bytes_key = placeholder.clone();
                         image_counter += 1;
                         image_infos.push(ImageInfo {
                             placeholder: placeholder.clone(),
                             original_alt: String::new(),
                             filename: filename.clone(),
+                            bytes_key: bytes_key.clone(),
                         });
                         image_lines.push(format!("![{placeholder}]({filename})"));
                         plain_image_lines.push(placeholder);
                         if options.extract_images {
                             images.push((filename.clone(), img_data.clone()));
                         }
-                        image_bytes_map.insert(filename, img_data);
+                        image_bytes_map.insert(bytes_key, img_data);
                     } else {
                         warnings.push(ConversionWarning {
                             code: WarningCode::ResourceLimitReached,

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -34,7 +34,11 @@ pub fn detect_format(path: &Path, header_bytes: &[u8]) -> Option<&'static str> {
     }
 
     // 3. JSON heuristic (fallback for unknown extensions): starts with { or [
-    if let Some(&first) = header_bytes.iter().find(|b| !b.is_ascii_whitespace())
+    // Skip optional UTF-8 BOM before scanning.
+    let bytes = header_bytes
+        .strip_prefix(&[0xEF, 0xBB, 0xBF])
+        .unwrap_or(header_bytes);
+    if let Some(&first) = bytes.iter().find(|b| !b.is_ascii_whitespace())
         && (first == b'{' || first == b'[')
     {
         return Some("json");
@@ -226,6 +230,14 @@ mod tests {
         let path = PathBuf::from("data.dat");
         let content = b"{ \"key\": \"value\" }";
         assert_eq!(detect_format(&path, content), Some("json"));
+    }
+
+    #[test]
+    fn test_detect_format_unknown_ext_with_json_utf8_bom_returns_json() {
+        let path = PathBuf::from("data.dat");
+        let mut content = vec![0xEF, 0xBB, 0xBF];
+        content.extend_from_slice(b"{\"key\":\"value\"}");
+        assert_eq!(detect_format(&path, &content), Some("json"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,7 @@ pub fn convert_file(
         });
     }
 
-    let header = &data[..data.len().min(16)];
-    let format = detection::detect_format(path, header);
+    let format = detection::detect_format(path, &data);
 
     // For ZIP-based formats, introspect to find the specific type
     let (format, is_zip_magic) = match format {
@@ -264,8 +263,7 @@ pub async fn convert_file_async(
         });
     }
 
-    let header = &data[..data.len().min(16)];
-    let format = detection::detect_format(path, header);
+    let format = detection::detect_format(path, &data);
 
     let (format, is_zip_magic) = match format {
         Some("zip") => (detection::detect_zip_format(&data), true),
@@ -545,6 +543,26 @@ mod tests {
         );
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_convert_file_unknown_ext_json_with_long_leading_whitespace() {
+        let dir = std::env::temp_dir().join("anytomd_test_json_whitespace_detect");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("payload.dat");
+        let mut data = vec![b' '; 40];
+        data.extend_from_slice(br#"{"k":1}"#);
+        std::fs::write(&file_path, data).unwrap();
+
+        let result = convert_file(&file_path, &ConversionOptions::default()).unwrap();
+        assert!(
+            result.markdown.contains("\"k\""),
+            "expected JSON conversion, markdown was: {}",
+            result.markdown
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,9 @@ pub fn convert_bytes(
     extension: &str,
     options: &ConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
+    let extension = extension.trim();
+    let extension_norm = extension.to_ascii_lowercase();
+
     if data.len() > options.max_input_bytes {
         return Err(ConvertError::InputTooLarge {
             size: data.len(),
@@ -152,7 +155,7 @@ pub fn convert_bytes(
         });
     }
 
-    if extension == "pdf" {
+    if extension_norm == "pdf" {
         return Err(ConvertError::FormatNotSupported {
             extension: "pdf".to_string(),
             reason: "PDF is intentionally unsupported — Gemini, ChatGPT, and Claude \
@@ -177,8 +180,8 @@ pub fn convert_bytes(
     // needs the extension for language detection (the Converter trait's
     // convert() method doesn't receive the extension).
     let code_conv = CodeConverter;
-    if code_conv.can_convert(extension, data) {
-        let result = code_conv.convert_with_extension(data, extension, options)?;
+    if code_conv.can_convert(&extension_norm, data) {
+        let result = code_conv.convert_with_extension(data, &extension_norm, options)?;
         return enforce_strict_mode(result, options.strict);
     }
 
@@ -196,14 +199,14 @@ pub fn convert_bytes(
     ];
 
     for conv in &converters {
-        if conv.can_convert(extension, data) {
+        if conv.can_convert(&extension_norm, data) {
             let result = conv.convert(data, options)?;
             return enforce_strict_mode(result, options.strict);
         }
     }
 
     Err(ConvertError::UnsupportedFormat {
-        extension: extension.to_string(),
+        extension: extension_norm,
     })
 }
 
@@ -296,6 +299,9 @@ pub async fn convert_bytes_async(
     extension: &str,
     options: &converter::AsyncConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
+    let extension = extension.trim();
+    let extension_norm = extension.to_ascii_lowercase();
+
     if data.len() > options.base.max_input_bytes {
         return Err(ConvertError::InputTooLarge {
             size: data.len(),
@@ -303,7 +309,7 @@ pub async fn convert_bytes_async(
         });
     }
 
-    if extension == "pdf" {
+    if extension_norm == "pdf" {
         return Err(ConvertError::FormatNotSupported {
             extension: "pdf".to_string(),
             reason: "PDF is intentionally unsupported — Gemini, ChatGPT, and Claude \
@@ -314,7 +320,7 @@ pub async fn convert_bytes_async(
 
     // For image-bearing formats, use convert_inner() + async resolve
     if let Some(ref describer) = options.async_image_describer {
-        match extension {
+        match extension_norm.as_str() {
             "docx" => {
                 let conv = converter::docx::DocxConverter;
                 let (mut result, pending) = conv.convert_inner(data, &options.base)?;
@@ -384,7 +390,7 @@ pub async fn convert_bytes_async(
     }
 
     // Fallback: use sync convert for non-image formats or when no async describer
-    convert_bytes(data, extension, &options.base)
+    convert_bytes(data, &extension_norm, &options.base)
 }
 
 #[cfg(test)]
@@ -440,6 +446,12 @@ mod tests {
         let data = b"caf\xe9";
         let result = convert_bytes(data, "txt", &ConversionOptions::default()).unwrap();
         assert!(!result.warnings.is_empty(), "expected decoding warning");
+    }
+
+    #[test]
+    fn test_convert_bytes_extension_case_insensitive() {
+        let result = convert_bytes(b"hello world", " TXT ", &ConversionOptions::default()).unwrap();
+        assert!(result.markdown.contains("hello world"));
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,7 @@ pub fn convert_bytes(
     extension: &str,
     options: &ConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
-    let extension = extension.trim();
-    let extension_norm = extension.to_ascii_lowercase();
+    let extension_norm = normalize_extension(extension);
 
     if data.len() > options.max_input_bytes {
         return Err(ConvertError::InputTooLarge {
@@ -231,6 +230,13 @@ fn enforce_strict_mode(
     })
 }
 
+fn normalize_extension(extension: &str) -> String {
+    extension
+        .trim()
+        .trim_start_matches('.')
+        .to_ascii_lowercase()
+}
+
 /// Convert a file at the given path to Markdown with async image description.
 ///
 /// The format is auto-detected from magic bytes and file extension.
@@ -297,8 +303,7 @@ pub async fn convert_bytes_async(
     extension: &str,
     options: &converter::AsyncConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
-    let extension = extension.trim();
-    let extension_norm = extension.to_ascii_lowercase();
+    let extension_norm = normalize_extension(extension);
 
     if data.len() > options.base.max_input_bytes {
         return Err(ConvertError::InputTooLarge {
@@ -449,6 +454,12 @@ mod tests {
     #[test]
     fn test_convert_bytes_extension_case_insensitive() {
         let result = convert_bytes(b"hello world", " TXT ", &ConversionOptions::default()).unwrap();
+        assert!(result.markdown.contains("hello world"));
+    }
+
+    #[test]
+    fn test_convert_bytes_extension_with_leading_dot() {
+        let result = convert_bytes(b"hello world", ".txt", &ConversionOptions::default()).unwrap();
         assert!(result.markdown.contains("hello world"));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,14 @@ pub fn convert_file(
     options: &ConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
     let path = path.as_ref();
+    let size = std::fs::metadata(path)?.len() as usize;
+    if size > options.max_input_bytes {
+        return Err(ConvertError::InputTooLarge {
+            size,
+            limit: options.max_input_bytes,
+        });
+    }
+
     let data = std::fs::read(path)?;
 
     if data.len() > options.max_input_bytes {
@@ -170,7 +178,8 @@ pub fn convert_bytes(
     // convert() method doesn't receive the extension).
     let code_conv = CodeConverter;
     if code_conv.can_convert(extension, data) {
-        return code_conv.convert_with_extension(data, extension, options);
+        let result = code_conv.convert_with_extension(data, extension, options)?;
+        return enforce_strict_mode(result, options.strict);
     }
 
     let converters: Vec<Box<dyn Converter>> = vec![
@@ -188,12 +197,35 @@ pub fn convert_bytes(
 
     for conv in &converters {
         if conv.can_convert(extension, data) {
-            return conv.convert(data, options);
+            let result = conv.convert(data, options)?;
+            return enforce_strict_mode(result, options.strict);
         }
     }
 
     Err(ConvertError::UnsupportedFormat {
         extension: extension.to_string(),
+    })
+}
+
+fn enforce_strict_mode(
+    result: ConversionResult,
+    strict: bool,
+) -> Result<ConversionResult, ConvertError> {
+    if !strict || result.warnings.is_empty() {
+        return Ok(result);
+    }
+
+    let first = &result.warnings[0];
+    let loc = first
+        .location
+        .as_deref()
+        .map(|l| format!(" ({l})"))
+        .unwrap_or_default();
+    Err(ConvertError::MalformedDocument {
+        reason: format!(
+            "strict mode: encountered warning [{:?}] {}{}",
+            first.code, first.message, loc
+        ),
     })
 }
 
@@ -212,6 +244,14 @@ pub async fn convert_file_async(
     options: &converter::AsyncConversionOptions,
 ) -> Result<ConversionResult, ConvertError> {
     let path = path.as_ref();
+    let size = std::fs::metadata(path)?.len() as usize;
+    if size > options.base.max_input_bytes {
+        return Err(ConvertError::InputTooLarge {
+            size,
+            limit: options.base.max_input_bytes,
+        });
+    }
+
     let data = std::fs::read(path)?;
 
     if data.len() > options.base.max_input_bytes {
@@ -289,7 +329,7 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
-                return Ok(result);
+                return enforce_strict_mode(result, options.base.strict);
             }
             "pptx" => {
                 let conv = converter::pptx::PptxConverter;
@@ -305,7 +345,7 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
-                return Ok(result);
+                return enforce_strict_mode(result, options.base.strict);
             }
             "xlsx" | "xls" => {
                 let conv = converter::xlsx::XlsxConverter;
@@ -321,7 +361,7 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
-                return Ok(result);
+                return enforce_strict_mode(result, options.base.strict);
             }
             ext if converter::image::ImageConverter.can_convert(ext, data) => {
                 let conv = converter::image::ImageConverter;
@@ -337,7 +377,7 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
-                return Ok(result);
+                return enforce_strict_mode(result, options.base.strict);
             }
             _ => {}
         }
@@ -376,6 +416,30 @@ mod tests {
         };
         let result = convert_bytes(data, "txt", &options);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_convert_bytes_strict_mode_escalates_warning() {
+        // Non-UTF8 bytes trigger a recoverable decoding warning in txt converter.
+        let data = b"caf\xe9";
+        let options = ConversionOptions {
+            strict: true,
+            ..Default::default()
+        };
+        let result = convert_bytes(data, "txt", &options);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            format!("{err}").contains("strict mode"),
+            "error should mention strict mode: {err}"
+        );
+    }
+
+    #[test]
+    fn test_convert_bytes_non_strict_keeps_warning() {
+        let data = b"caf\xe9";
+        let result = convert_bytes(data, "txt", &ConversionOptions::default()).unwrap();
+        assert!(!result.warnings.is_empty(), "expected decoding warning");
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -576,4 +576,24 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_convert_file_unknown_ext_json_with_utf8_bom() {
+        let dir = std::env::temp_dir().join("anytomd_test_json_bom_detect");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("payload.dat");
+        let mut data = vec![0xEF, 0xBB, 0xBF];
+        data.extend_from_slice(br#"{"k":1}"#);
+        std::fs::write(&file_path, data).unwrap();
+
+        let result = convert_file(&file_path, &ConversionOptions::default()).unwrap();
+        assert!(
+            result.markdown.contains("\"k\""),
+            "expected JSON conversion, markdown was: {}",
+            result.markdown
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -155,6 +155,18 @@ fn test_cli_strict_flag() {
         .stdout(predicate::str::contains("Alice"));
 }
 
+/// --strict should fail when conversion would otherwise emit warnings.
+#[test]
+fn test_cli_strict_flag_fails_on_warning() {
+    cmd()
+        .args(["--strict", "--format", "txt"])
+        .write_stdin(vec![0xE9])
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("strict mode"));
+}
+
 /// Multiple files where one is missing: partial success with exit code 1.
 #[test]
 fn test_cli_partial_failure_multiple_files() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -97,6 +97,22 @@ fn test_cli_stdin_csv_format() {
         .stdout(predicate::str::contains("| Name | Age |"));
 }
 
+/// Stdin JSON with UTF-16 LE BOM should be decoded.
+#[test]
+fn test_cli_stdin_json_utf16_bom() {
+    let mut input = vec![0xFF, 0xFE];
+    for code_unit in "{\"k\":1}\n".encode_utf16() {
+        input.extend_from_slice(&code_unit.to_le_bytes());
+    }
+
+    cmd()
+        .args(["--format", "json"])
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"k\""));
+}
+
 /// --format overrides file extension detection.
 #[test]
 fn test_cli_format_override_on_file() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -74,6 +74,17 @@ fn test_cli_stdin_with_uppercase_format() {
         .stdout(predicate::str::contains("hello world"));
 }
 
+/// Stdin format should accept a leading dot.
+#[test]
+fn test_cli_stdin_with_dotted_format() {
+    cmd()
+        .args(["--format", ".txt"])
+        .write_stdin("hello world")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"));
+}
+
 /// Stdin with CSV format.
 #[test]
 fn test_cli_stdin_csv_format() {

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -63,6 +63,17 @@ fn test_cli_stdin_with_format() {
         .stdout(predicate::str::contains("hello world"));
 }
 
+/// Stdin format should be case-insensitive.
+#[test]
+fn test_cli_stdin_with_uppercase_format() {
+    cmd()
+        .args(["--format", "TXT"])
+        .write_stdin("hello world")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello world"));
+}
+
 /// Stdin with CSV format.
 #[test]
 fn test_cli_stdin_csv_format() {


### PR DESCRIPTION
## Summary
- add `AGENTS.md` guidance to read `CLAUDE.md` first
- enforce `strict` mode consistently so warning-producing conversions fail in strict mode
- harden input-size checks by validating file size before full file read
- fix OOXML relationship/path handling across DOCX/PPTX/XLSX
  - absolute target paths (`/word/...`, `/ppt/...`, `/xl/...`)
  - dot-segment paths (`./...`, `../...`) via normalized package path resolution
  - disambiguate duplicate image basenames using per-image byte lookup keys
  - unescape XML entities in `.rels` target attributes
- make format extension handling more robust
  - case-insensitive extensions
  - accept dotted format hints (e.g. `.txt`)
- improve unknown-extension JSON detection and conversion behavior
  - detect JSON with long leading whitespace
  - detect/parse UTF-8 BOM JSON
  - parse UTF-16 BOM JSON with explicit conversion warnings
- add focused regression tests for each reproduced bug case

## Why
- each change is based on an actual reproduction against `origin/main`
- fixes target user-facing conversion failures or strict-mode contract mismatches
- prevents silent fallback behavior in common real-world inputs (OOXML path variants, BOM/encoding variants, format hint variants)

## Testing
- `cargo fmt --check`
- `cargo test --quiet`
- targeted regression tests run during implementation for each bug

Related: none found (`gh issue list --state open --limit 20` returned no open issues)
