### PR TITLE
chore: release v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anytomd"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release v1.2.1 containing bug fixes and safety hardening since v1.2.0:

- **OOXML path resolution**: normalize dot segments, handle absolute/relative targets, unescape XML entities in relationship URLs
- **Image disambiguation**: new `bytes_key` field prevents images with identical basenames from overwriting each other (DOCX, PPTX, XLSX)
- **JSON BOM support**: handle UTF-8 and UTF-16 BOM-prefixed JSON files with conversion warnings
- **Extension normalization**: case-insensitive, leading-dot-tolerant extension handling in `convert_bytes` / `convert_file` APIs and CLI
- **Format detection**: use full file data instead of 16-byte header for JSON heuristic detection
- **Strict mode**: enforce strict mode consistently in `convert_bytes` and `convert_bytes_async`
- **Security hardening**: pre-read file size check (OOM prevention), ZIP budget u64→usize overflow clamping

All changes are accompanied by regression tests. No new features or breaking changes.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)