### PR TITLE
feat: publish WASM package to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: npm publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build WASM package
+        run: wasm-pack build --target bundler --no-default-features --features wasm,async-gemini
+      - name: Publish to npm
+        run: cd pkg && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ reference/
 
 # macOS
 .DS_Store
+
+# wasm-pack build output
+pkg/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["markdown", "converter", "document", "llm"]
 categories = ["parser-implementations", "text-processing"]
 exclude = ["examples/"]
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [features]
 default = ["async-gemini"]
 async = ["dep:futures-util"]

--- a/README.md
+++ b/README.md
@@ -119,8 +119,28 @@ Data Overview
 
 ## Installation
 
+### Rust (Cargo)
+
 ```sh
 cargo add anytomd
+```
+
+### npm (WASM)
+
+```sh
+npm install anytomd
+```
+
+```js
+import init, { convertBytes } from 'anytomd';
+
+await init();
+
+const response = await fetch('document.docx');
+const bytes = new Uint8Array(await response.arrayBuffer());
+
+const result = convertBytes(bytes, 'docx');
+console.log(result.markdown);
 ```
 
 ### Feature Flags


### PR DESCRIPTION
## Summary

- Add CI workflow (`.github/workflows/npm-publish.yml`) that auto-publishes the WASM package to npm on every GitHub release
- Add `pkg/` to `.gitignore` to prevent committing wasm-pack build output
- Add `[lib] crate-type = ["cdylib", "rlib"]` to `Cargo.toml` — required by `wasm-pack build`
- Update `README.md` with npm installation section (`npm install anytomd`)

## Details

The npm publish workflow triggers on `release: published` events. It builds the WASM package with `--target bundler --no-default-features --features wasm,async-gemini` (full feature set) and publishes to npm with `--access public`.

**Required setup:** Add `NPM_TOKEN` as a GitHub Actions repository secret (from npmjs.com > Access Tokens > Automation).

After merging, the current version (v1.2.1) needs a manual `wasm-pack build --target bundler --no-default-features --features wasm,async-gemini && cd pkg && npm publish --access public`. Future releases will auto-publish.

## Test plan

- [x] `wasm-pack build --target bundler --no-default-features --features wasm,async-gemini` succeeds
- [x] Generated `pkg/package.json` has correct name (`anytomd`), version (`1.2.1`), and metadata
- [x] `cargo build && cargo test && cargo clippy -- -D warnings` passes (native build unaffected)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)