### PR TITLE
chore: release v1.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ reference/
 
 # wasm-pack build output
 pkg/
+
+# Local environment files — never commit or publish
+.env
+.env.*
+!.env.example

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anytomd"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/anytomd"
 readme = "README.md"
 keywords = ["markdown", "converter", "document", "llm"]
 categories = ["parser-implementations", "text-processing"]
-exclude = ["examples/"]
+exclude = ["examples/", ".env", ".env.*", "**/.env", "**/.env.*"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -271,10 +271,8 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                         plain_start_pos: state.plain_output.len(),
                     });
                 }
-                "p" => {
-                    if !state.in_table_cell() {
-                        state.both_ensure_blank_line();
-                    }
+                "p" if !state.in_table_cell() => {
+                    state.both_ensure_blank_line();
                 }
                 "a" => {
                     let href = el.attr("href").unwrap_or("").to_string();
@@ -297,11 +295,9 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     state.push_str("*");
                     // plain text: no markers
                 }
-                "code" => {
-                    if !state.in_pre {
-                        state.push_str("`");
-                        // plain text: no backtick
-                    }
+                "code" if !state.in_pre => {
+                    state.push_str("`");
+                    // plain text: no backtick
                 }
                 "pre" => {
                     state.in_pre = true;
@@ -463,10 +459,8 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     }
                 }
             }
-            "p" => {
-                if !state.in_table_cell() {
-                    state.both_ensure_blank_line();
-                }
+            "p" if !state.in_table_cell() => {
+                state.both_ensure_blank_line();
             }
             "a" => {
                 if let Some(pending) = state.pending_link.take() {
@@ -497,11 +491,9 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 state.push_str("*");
                 // plain text: no closing marker
             }
-            "code" => {
-                if !state.in_pre {
-                    state.push_str("`");
-                    // plain text: no closing backtick
-                }
+            "code" if !state.in_pre => {
+                state.push_str("`");
+                // plain text: no closing backtick
             }
             "pre" => {
                 state.ensure_newline();

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -659,11 +659,9 @@ fn parse_notes(xml: &str) -> Option<String> {
                     }
                 }
             }
-            Ok(Event::Text(ref e)) => {
-                if in_shape && in_text && in_run {
-                    let text = e.unescape().unwrap_or_default().to_string();
-                    current_paragraph.push_str(&text);
-                }
+            Ok(Event::Text(ref e)) if in_shape && in_text && in_run => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                current_paragraph.push_str(&text);
             }
             Ok(Event::End(ref e)) => {
                 let local = e.local_name();


### PR DESCRIPTION
## Summary

Patch release containing a security fix for the publishing pipeline.

Versions **v0.1.0 through v1.2.1** inadvertently shipped a `.env` file containing a real Gemini API key. The leak was reported privately by an external security researcher. The credential has already been **revoked**, and the affected versions will be **yanked** from crates.io after this release ships. A separate request to crates.io support will be filed to purge the source archives (yanking alone does not remove published source from docs.rs).

This release prevents recurrence by:

- adding `.env` and `.env.*` to `.gitignore` so the file is no longer untracked
- adding `.env`, `.env.*`, `**/.env`, `**/.env.*` to `package.exclude` in `Cargo.toml` as a second line of defense — even if `cargo publish --allow-dirty` is run with a `.env` present, the exclude list will drop it

## Drive-by clippy fix

Rust 1.95 (the current `stable` on CI runners) strengthened `clippy::collapsible_match`, which started flagging five existing match arms in `src/converter/html.rs` and `src/converter/pptx.rs`. CI was red on every push regardless of this PR's contents, so the fix is bundled here to unblock the security release. Each affected arm has a no-op `_ => {}` fallthrough, so collapsing the inner `if` into a match guard is semantically equivalent.

No source code behavior changes; library and CLI behavior is unchanged.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all tests pass (Rust 1.94.1 and 1.95)
- [x] `cargo clippy -- -D warnings` — clean (Rust 1.95)
- [x] `cargo clippy --features async -- -D warnings` — clean
- [x] `cargo clippy --features async-gemini -- -D warnings` — clean
- [x] `cargo clippy --lib --target wasm32-unknown-unknown --no-default-features --features wasm -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo package --list --allow-dirty` with a sentinel `.env` in the worktree — sentinel does **not** appear in the package contents
- [ ] CI passes on PR

## Post-merge follow-up

1. Publish v1.2.2 to crates.io (`cargo publish` from `main`).
2. Yank v0.1.0 through v1.2.1 from crates.io.
3. Email help@crates.io to request hard removal of the affected versions and docs.rs caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)