### PR TITLE
chore: harden publish pipeline against local-tooling leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ pkg/
 .env
 .env.*
 !.env.example
+
+# Local tooling state (Claude Code, oh-my-claudecode, IDEs) — never commit or publish
+# These directories hold per-user/per-machine state that must not ship to crates.io.
+# To intentionally share a file from one of these dirs, add an explicit `!path` exception.
+.claude/
+.omc/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,20 @@ Follow all steps in order — do not skip any.
 7. **Create GitHub release** — `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes --latest` (from `main` at the merge commit)
 8. **Verify sync** — confirm `cargo search anytomd` matches the GitHub release tag and `Cargo.toml`
 
+### Pre-publish Safety Checks
+
+**Mandatory before step 6 (`cargo publish`).** Skipping these has historically leaked credentials — treat as non-negotiable.
+
+1. **Working tree must be clean.** `git status --short` must produce no output. If untracked files appear (local IDE/tooling state, scratch files, generated artifacts), add them to `.gitignore` in a **separate PR** before publishing. Never proceed with `--allow-dirty` to "just get past it."
+2. **Audit the package contents.** Run:
+   ```bash
+   cargo package --list | grep -E '\.env|\.omc|\.claude|secret|credential|token|key|password'
+   ```
+   The grep must return nothing. If anything matches, stop and add the file to both `.gitignore` AND `Cargo.toml`'s `package.exclude` (defense in depth) before retrying.
+3. **`--allow-dirty` is off-limits.** Do not use `cargo publish --allow-dirty` unless every uncommitted/untracked file in the working tree has been inspected and individually confirmed safe to ship to crates.io. Any uncertainty → do not publish.
+
+**Background — the v1.2.1 incident.** Versions v0.1.0 through v1.2.1 leaked an active Google Gemini API key via a `.env` file that was untracked, not in `.gitignore`, and got bundled when `cargo publish --allow-dirty` was used. v1.2.2 added `.env` patterns to both `.gitignore` and `Cargo.toml`'s `package.exclude`. A near-miss followed during the v1.2.2 publish itself when the `.omc/` local-tooling directory would have shipped the same way had `--allow-dirty` been reused. Both incidents trace to the same root cause: untracked working-tree state being included by `cargo package`. Steps 1–3 above exist to make that root cause unreachable.
+
 ### Version Sync Rules
 
 - **One version, three places**: `Cargo.toml` (source of truth) = crates.io = GitHub release tag


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to the v1.2.1 credential leak (PR #88). Closes the same root cause from a different angle: untracked working-tree files getting bundled by `cargo publish`.

### `.gitignore`
Adds `.claude/` and `.omc/`. Both directories hold per-user/per-machine state from local tooling (Claude Code, oh-my-claudecode) and must never reach crates.io. The `.omc/` case was discovered as a near-miss during the v1.2.2 publish — `cargo publish` correctly rejected the dirty tree, but a maintainer reflexively reaching for `--allow-dirty` would have shipped it.

### `CLAUDE.md`
Adds a new **Pre-publish Safety Checks** subsection under Release Management that makes three rules mandatory before `cargo publish`:

1. Working tree must be clean (`git status --short` empty); fix the gitignore in a separate PR rather than `--allow-dirty`-ing past it.
2. Audit `cargo package --list` with a sensitive-pattern grep (`.env|.omc|.claude|secret|credential|token|key|password`); any match blocks the release.
3. `cargo publish --allow-dirty` is off-limits unless every uncommitted/untracked file is individually inspected.

Includes a background note documenting both the v1.2.1 incident and the v1.2.2 near-miss so the rationale survives the next maintainer or contributor.

## Test plan

- [x] Sentinel verification: created `.omc/state/test.json` and `.claude/settings.local.json`, ran `cargo package --list | grep -E '\.env|\.omc|\.claude|secret|credential|token|key|password'` — no match
- [x] `git status --short` shows only the two intentional changes after the new gitignore patterns are picked up
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)