### PR TITLE
chore: comprehensive publish hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,5 +27,11 @@ Thumbs.db
 # Mutation testing output
 **/mutants.out*/
 
-# Claude config
+# Local tooling state — Claude Code, oh-my-claudecode
 .claude/
+.omc/
+
+# Local environment files — never bake into images
+.env
+.env.*
+!.env.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,43 @@ jobs:
       - name: Run WASM tests
         run: wasm-pack test --node --no-default-features --features wasm
 
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # gitleaks needs full history to scan past commits
+          fetch-depth: 0
+
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit dependencies for known vulnerabilities
+        # Allowed-to-fail: a fresh advisory shouldn't block unrelated PRs;
+        # the job still surfaces it loudly in the run log.
+        continue-on-error: true
+        run: cargo audit
+
+      - name: Audit publish package contents
+        # Belt-and-suspenders against the v1.2.1 leak class:
+        # if anything sensitive ever ends up in `cargo package --list`,
+        # CI fails before crates.io ever sees it.
+        run: |
+          set -e
+          list=$(cargo package --list 2>&1)
+          echo "$list"
+          if echo "$list" | grep -E '(^|/)\.env(\.|$)|(^|/)\.omc/|(^|/)\.claude/|\.pem$|\.key$|id_rsa|credentials|secrets?\.' ; then
+            echo "::error::Sensitive file pattern found in publish package contents"
+            exit 1
+          fi
+

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,27 @@ pkg/
 # To intentionally share a file from one of these dirs, add an explicit `!path` exception.
 .claude/
 .omc/
+.vscode/
+.cursor/
+.idea/
+
+# Editor swap and backup files
+*.swp
+*.swo
+*~
+*.bak
+
+# Build/coverage artifacts that may embed paths or secrets
+*.log
+coverage/
+*.profraw
+lcov.info
+tarpaulin-report.html
+
+# Credential-shaped files — categorical block, even if accidentally created
+*.pem
+*.key
+id_rsa*
+id_ed25519*
+*credentials*
+*secrets*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,15 @@ documentation = "https://docs.rs/anytomd"
 readme = "README.md"
 keywords = ["markdown", "converter", "document", "llm"]
 categories = ["parser-implementations", "text-processing"]
-exclude = ["examples/", ".env", ".env.*", "**/.env", "**/.env.*"]
+# Whitelist what ships to crates.io. Anything outside this list — including
+# any future `.env`, IDE state, dev docs, CI configs — cannot leak by accident.
+# Cargo always auto-includes Cargo.toml, Cargo.lock, Cargo.toml.orig,
+# .cargo_vcs_info.json, and the file referenced by `readme`.
+include = [
+    "src/**/*.rs",
+    "/LICENSE",
+    "/README.md",
+]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary

Layered defenses against the v1.2.1 leak class. Each layer is independent — disabling any one still leaves the others holding.

| # | Layer | What | Where |
|---|---|---|---|
| 1 | `Cargo.toml` whitelist | `include = ["src/**/*.rs", "/LICENSE", "/README.md"]` — published surface is now exactly source code + license + readme + cargo's auto files. Anything else cannot leak. | `Cargo.toml` |
| 2 | `.gitignore` extensions | IDE/editor state (`.vscode/`, `.cursor/`, `.idea/`), swap/backup files, build/coverage artifacts, and a categorical credential block (`*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `*secrets*`) | `.gitignore` |
| 3 | `.dockerignore` parity | `.omc/`, `.env`, `.env.*` so `COPY . .` can't bake them into a future container image | `.dockerignore` |
| 4 | CI secret scan | `gitleaks/gitleaks-action@v2` over full git history — would have caught v1.2.1 before publish | `ci.yml` (new `security` job) |
| 5 | CI dependency audit | `cargo audit` for known RUSTSEC advisories; `continue-on-error: true` so advisory churn doesn't block unrelated PRs | same job |
| 6 | CI publish audit | `cargo package --list` piped through a sensitive-pattern grep; CI fails before crates.io ever sees a leak. Belt and suspenders for Layer 1 | same job |

## Package contents diff

Drops these dev-only files from the published crate (none used by consumers):

- `Dockerfile`, `docker-compose.yml`, `.dockerignore`
- `.github/` (CI configs, issue templates)
- `AGENTS.md`, `CLAUDE.md`, `TECH_SPEC.md`
- `.gitignore`
- `tests/` (test code + binary fixtures)

After this PR, `cargo package --list` returns 35 files: `src/**/*.rs` (29 source files) + `Cargo.toml`/`Cargo.lock`/`Cargo.toml.orig`/`.cargo_vcs_info.json` + `LICENSE` + `README.md`.

## Test plan

- [x] `cargo package --list --allow-dirty` — exactly the 35 expected files; sensitive-pattern grep matches nothing
- [x] `cargo build && cargo test && cargo clippy -- -D warnings && cargo fmt --check` all green
- [ ] CI passes on PR (gitleaks should be green — no secrets in tree; cargo audit may surface advisories but is non-blocking; publish audit will assert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)