### PR TITLE
feat: comment extraction for DOCX and PPTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ anytomd --plain-text document.docx
 # Plain text from stdin
 echo "Name,Age" | anytomd --format csv --plain-text
 
+# Extract comments (DOCX/PPTX) into an appended Comments section
+anytomd --extract-comments document.docx
+
 # Image descriptions via Gemini (requires GEMINI_API_KEY env var)
 export GEMINI_API_KEY=your-key
 anytomd --gemini presentation.pptx
@@ -319,6 +322,47 @@ for (filename, bytes) in &result.images {
     std::fs::write(filename, bytes).unwrap();
 }
 ```
+
+### Extracting Comments (DOCX / PPTX)
+
+Setting `extract_comments` appends a `# Comments` section to the end of the
+output (both Markdown and plain text). Each comment records the commenter, the
+comment body, and the source — the commented-on text for DOCX, or the slide
+label for PPTX (whose comments are anchored to a point, not a text span).
+Replies are flattened and marked `(reply)`; the flag is a no-op for other
+formats.
+
+```rust
+use anytomd::{convert_file, ConversionOptions};
+
+let options = ConversionOptions {
+    extract_comments: true,
+    ..Default::default()
+};
+let result = convert_file("document.docx", &options).unwrap();
+println!("{}", result.markdown);
+```
+
+Example appended section:
+
+```markdown
+# Comments
+
+## 1
+- **author**: Jane Smith (2024-01-15T09:30:00Z)
+- **comment**: Please revise this paragraph.
+- **source**: the quick brown fox
+```
+
+Notes:
+
+- **DOCX:** commenter identity comes from the comment author and date; the
+  source is the commented-on text (collapsed to one line, capped at 200
+  characters). Ranges in the body, headers, footers, footnotes, and endnotes
+  are all scanned. Threaded replies are detected via `commentsExtended.xml`.
+- **PPTX:** both the legacy (`commentAuthors.xml`) and modern
+  (`authors.xml` / threaded) comment schemes are supported. The source is the
+  slide label (e.g. `Slide 2: Quarterly Results`).
 
 ### LLM-Based Image Descriptions
 
@@ -438,6 +482,7 @@ pub async fn convert_bytes_async(
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `extract_images` | `bool` | `false` | Extract embedded images into `result.images` |
+| `extract_comments` | `bool` | `false` | Append a `# Comments` section (DOCX/PPTX only) |
 | `max_total_image_bytes` | `usize` | 50 MB | Hard cap for total extracted image bytes |
 | `max_input_bytes` | `usize` | 100 MB | Maximum input file size |
 | `max_uncompressed_zip_bytes` | `usize` | 500 MB | ZIP bomb guard |

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -125,6 +125,8 @@ pub struct ConversionWarning {
 pub struct ConversionOptions {
     /// Extract embedded images into `ConversionResult.images`
     pub extract_images: bool,
+    /// Extract comments (DOCX/PPTX) into an appended `# Comments` section
+    pub extract_comments: bool,
     /// Hard cap for total extracted image bytes per document
     pub max_total_image_bytes: usize,
     /// If true, return an error on recoverable parse failures
@@ -281,6 +283,12 @@ word/_rels/document.xml.rels — relationship mappings (image refs)
 | Hyperlinks | `<w:hyperlink>` + rels | `[text](url)` |
 | Images | `<w:drawing>` + rels → media/ | Extract to `ConversionResult.images` |
 | Lists | `<w:numPr>` + numbering.xml | `- item` or `1. item` |
+| Comments (opt-in) | `comments.xml` + `commentRangeStart/End` in body/headers/footers/footnotes/endnotes; threads via `commentsExtended.xml` | Appended `# Comments` section |
+
+When `extract_comments` is set, comments are appended after the body as a
+`# Comments` section: per comment, the author + date, the comment body, and
+the commented-on text (`source`, collapsed and capped at 200 chars). Replies
+are flattened and marked `(reply)`.
 
 **MarkItDown comparison:**
 - MarkItDown: DOCX → HTML (via mammoth) → Markdown (via markdownify) — two conversion steps
@@ -306,6 +314,11 @@ ppt/media/*                — embedded images
 | Tables | `<a:tbl>` → `<a:tr>` → `<a:tc>` | Pipe-delimited MD table |
 | Speaker notes | `notesSlide{N}.xml` → `<a:t>` | `> Note: ...` (blockquote) |
 | Images | `<a:blip>` + rels → media/ | Extract to `ConversionResult.images` |
+| Comments (opt-in) | legacy `commentAuthors.xml` + `comments/comment{N}.xml`; modern `authors.xml` + `comments/modernComment_*.xml` (threaded) | Appended `# Comments` section |
+
+When `extract_comments` is set, both the legacy and modern comment schemes are
+parsed. Because PPTX comments are point-anchored (not text-anchored), the
+`source` for each comment is the slide label (`Slide N: Title`).
 
 **Output structure per slide:**
 ```markdown

--- a/src/converter/comments.rs
+++ b/src/converter/comments.rs
@@ -257,7 +257,10 @@ mod tests {
 
     #[test]
     fn test_body_display_reply_prefixed() {
-        assert_eq!(body_display(&c("A", "Agreed.", "src", true)), "(reply) Agreed.");
+        assert_eq!(
+            body_display(&c("A", "Agreed.", "src", true)),
+            "(reply) Agreed."
+        );
     }
 
     #[test]

--- a/src/converter/comments.rs
+++ b/src/converter/comments.rs
@@ -1,0 +1,360 @@
+//! Shared model and rendering for extracted document comments.
+//!
+//! DOCX and PPTX converters collect comments into [`Comment`] values during
+//! parsing (gated by `ConversionOptions::extract_comments`). After the document
+//! body is rendered, [`append_comments`] appends a `# Comments` section to both
+//! the Markdown and plain-text output.
+//!
+//! The rendered Markdown structure is:
+//!
+//! ```text
+//! # Comments
+//!
+//! ## 1
+//! - **author**: <identity> (<date>)
+//! - **comment**: <body>
+//! - **source**: <commented-on text>
+//! ```
+//!
+//! The plain-text form mirrors the same layout with all Markdown markers
+//! stripped (`Comments` / `1` / `author:` / `comment:` / `source:`).
+
+/// A single extracted comment, ready for rendering.
+///
+/// Field values are already normalized by the converter that produced them
+/// (whitespace collapsed, `source` capped, `author` formatted). The renderer
+/// does not transform them further except for the reply prefix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Comment {
+    /// Commenter identity, pre-formatted as `Name` or `Name (date)`.
+    pub(crate) author: String,
+    /// Comment body text (plain, whitespace-collapsed, uncapped).
+    pub(crate) body: String,
+    /// The text the comment was anchored to (DOCX range, capped) or a slide
+    /// label (PPTX). May be empty.
+    pub(crate) source: String,
+    /// Whether this comment is a reply within a thread.
+    pub(crate) is_reply: bool,
+}
+
+/// Maximum number of characters retained for a comment's `source` text.
+pub(crate) const SOURCE_CAP: usize = 200;
+
+/// Collapse all runs of whitespace (spaces, tabs, newlines) into single spaces
+/// and trim the ends.
+///
+/// Used to flatten multi-paragraph comment bodies and ranged source text into a
+/// single line suitable for a Markdown list item.
+pub(crate) fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Truncate `s` to at most `max_chars` Unicode scalar values, appending `…`
+/// when truncation occurs.
+///
+/// Truncation always lands on a character boundary, so multi-byte characters
+/// (CJK, emoji) are never split mid-byte.
+pub(crate) fn cap_text(s: &str, max_chars: usize) -> String {
+    // `nth(max_chars)` yields the byte index of the character just past the cap
+    // (0-indexed), which is exactly the truncation point and always a char
+    // boundary. `None` means the string is within the cap.
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => {
+            let mut out = String::with_capacity(idx + '…'.len_utf8());
+            out.push_str(&s[..idx]);
+            out.push('…');
+            out
+        }
+        None => s.to_string(),
+    }
+}
+
+/// Format the `author` field from a raw author name and date string.
+///
+/// - Empty author becomes `Unknown`.
+/// - A present date is emitted verbatim in parentheses (no validation).
+/// - An empty date yields the author name alone (no empty parentheses).
+pub(crate) fn format_author(author: &str, date: &str) -> String {
+    let author = author.trim();
+    let author = if author.is_empty() { "Unknown" } else { author };
+    let date = date.trim();
+    if date.is_empty() {
+        author.to_string()
+    } else {
+        format!("{author} ({date})")
+    }
+}
+
+/// Render the comment body for display, prefixing replies with `(reply)`.
+fn body_display(c: &Comment) -> String {
+    if c.is_reply {
+        if c.body.is_empty() {
+            "(reply)".to_string()
+        } else {
+            format!("(reply) {}", c.body)
+        }
+    } else {
+        c.body.clone()
+    }
+}
+
+/// Render comments as a Markdown `# Comments` section.
+fn render_comments_md(comments: &[Comment]) -> String {
+    let mut out = String::from("# Comments\n");
+    for (i, c) in comments.iter().enumerate() {
+        out.push_str(&format!("\n## {}\n", i + 1));
+        out.push_str(&format!("- **author**: {}\n", c.author));
+        out.push_str(&format!("- **comment**: {}\n", body_display(c)));
+        out.push_str(&format!("- **source**: {}\n", c.source));
+    }
+    out
+}
+
+/// Render comments as a plain-text section (Markdown markers stripped).
+fn render_comments_plain(comments: &[Comment]) -> String {
+    let mut out = String::from("Comments\n");
+    for (i, c) in comments.iter().enumerate() {
+        out.push_str(&format!("\n{}\n", i + 1));
+        out.push_str(&format!("author: {}\n", c.author));
+        out.push_str(&format!("comment: {}\n", body_display(c)));
+        out.push_str(&format!("source: {}\n", c.source));
+    }
+    out
+}
+
+/// Append a rendered section to a buffer, separated by one blank line.
+///
+/// If the buffer has no meaningful content, it is replaced by the section
+/// (no leading blank lines). Otherwise trailing whitespace is trimmed and a
+/// single blank line is inserted before the section.
+fn append_section(buf: &mut String, section: &str) {
+    let keep = buf.trim_end().len();
+    if keep == 0 {
+        *buf = section.to_string();
+        return;
+    }
+    buf.truncate(keep);
+    buf.push_str("\n\n");
+    buf.push_str(section);
+}
+
+/// Append the `# Comments` section to both Markdown and plain-text output.
+///
+/// No-op when `comments` is empty (the section is omitted entirely).
+pub(crate) fn append_comments(
+    markdown: &mut String,
+    plain_text: &mut String,
+    comments: &[Comment],
+) {
+    if comments.is_empty() {
+        return;
+    }
+    append_section(markdown, &render_comments_md(comments));
+    append_section(plain_text, &render_comments_plain(comments));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(author: &str, body: &str, source: &str, is_reply: bool) -> Comment {
+        Comment {
+            author: author.to_string(),
+            body: body.to_string(),
+            source: source.to_string(),
+            is_reply,
+        }
+    }
+
+    // ---- collapse_ws ----
+
+    #[test]
+    fn test_collapse_ws_newlines_and_tabs_to_space() {
+        assert_eq!(collapse_ws("a\nb\tc"), "a b c");
+    }
+
+    #[test]
+    fn test_collapse_ws_runs_collapsed_and_trimmed() {
+        assert_eq!(collapse_ws("  a   \n\n  b  "), "a b");
+    }
+
+    #[test]
+    fn test_collapse_ws_empty() {
+        assert_eq!(collapse_ws("   \n\t "), "");
+    }
+
+    #[test]
+    fn test_collapse_ws_cjk_preserved() {
+        assert_eq!(collapse_ws("한국어\n中文"), "한국어 中文");
+    }
+
+    // ---- cap_text ----
+
+    #[test]
+    fn test_cap_text_under_limit_unchanged() {
+        assert_eq!(cap_text("hello", 200), "hello");
+    }
+
+    #[test]
+    fn test_cap_text_exact_limit_unchanged() {
+        let s = "a".repeat(200);
+        assert_eq!(cap_text(&s, 200), s);
+    }
+
+    #[test]
+    fn test_cap_text_over_limit_truncated_with_ellipsis() {
+        let s = "a".repeat(201);
+        let out = cap_text(&s, 200);
+        assert_eq!(out.chars().count(), 201); // 200 + ellipsis
+        assert!(out.ends_with('…'));
+        assert_eq!(&out[..200], &"a".repeat(200));
+    }
+
+    #[test]
+    fn test_cap_text_cjk_not_split_mid_char() {
+        // 250 CJK chars (3 bytes each) — must truncate on a char boundary.
+        let s = "한".repeat(250);
+        let out = cap_text(&s, 200);
+        assert_eq!(out.chars().count(), 201);
+        assert!(out.ends_with('…'));
+        // Round-trips as valid UTF-8 (no panic on slice) and is all 한 + …
+        assert_eq!(out.chars().filter(|&ch| ch == '한').count(), 200);
+    }
+
+    // ---- format_author ----
+
+    #[test]
+    fn test_format_author_name_and_date() {
+        assert_eq!(
+            format_author("Jane Smith", "2024-01-15T09:30:00Z"),
+            "Jane Smith (2024-01-15T09:30:00Z)"
+        );
+    }
+
+    #[test]
+    fn test_format_author_empty_date_name_only() {
+        assert_eq!(format_author("Jane Smith", ""), "Jane Smith");
+        assert_eq!(format_author("Jane Smith", "   "), "Jane Smith");
+    }
+
+    #[test]
+    fn test_format_author_empty_author_unknown() {
+        assert_eq!(format_author("", ""), "Unknown");
+        assert_eq!(format_author("   ", ""), "Unknown");
+    }
+
+    #[test]
+    fn test_format_author_unknown_with_date() {
+        assert_eq!(format_author("", "2024-01-15"), "Unknown (2024-01-15)");
+    }
+
+    // ---- body_display ----
+
+    #[test]
+    fn test_body_display_non_reply() {
+        assert_eq!(body_display(&c("A", "Hello", "src", false)), "Hello");
+    }
+
+    #[test]
+    fn test_body_display_reply_prefixed() {
+        assert_eq!(body_display(&c("A", "Agreed.", "src", true)), "(reply) Agreed.");
+    }
+
+    #[test]
+    fn test_body_display_reply_empty_body() {
+        assert_eq!(body_display(&c("A", "", "src", true)), "(reply)");
+    }
+
+    // ---- render_comments_md ----
+
+    #[test]
+    fn test_render_comments_md_matches_spec() {
+        let comments = vec![
+            c(
+                "Jane Smith (2024-01-15T09:30:00Z)",
+                "Please revise this.",
+                "the quick brown fox",
+                false,
+            ),
+            c("Unknown", "Agreed.", "jumped over", true),
+        ];
+        let expected = "# Comments\n\
+            \n## 1\n\
+            - **author**: Jane Smith (2024-01-15T09:30:00Z)\n\
+            - **comment**: Please revise this.\n\
+            - **source**: the quick brown fox\n\
+            \n## 2\n\
+            - **author**: Unknown\n\
+            - **comment**: (reply) Agreed.\n\
+            - **source**: jumped over\n";
+        assert_eq!(render_comments_md(&comments), expected);
+    }
+
+    // ---- render_comments_plain ----
+
+    #[test]
+    fn test_render_comments_plain_matches_layout() {
+        let comments = vec![
+            c(
+                "Jane Smith (2024-01-15T09:30:00Z)",
+                "Please revise this.",
+                "the quick brown fox",
+                false,
+            ),
+            c("Unknown", "Agreed.", "jumped over", true),
+        ];
+        let expected = "Comments\n\
+            \n1\n\
+            author: Jane Smith (2024-01-15T09:30:00Z)\n\
+            comment: Please revise this.\n\
+            source: the quick brown fox\n\
+            \n2\n\
+            author: Unknown\n\
+            comment: (reply) Agreed.\n\
+            source: jumped over\n";
+        assert_eq!(render_comments_plain(&comments), expected);
+        // Plain text must not contain Markdown markers.
+        assert!(!render_comments_plain(&comments).contains('#'));
+        assert!(!render_comments_plain(&comments).contains('*'));
+    }
+
+    // ---- append_comments ----
+
+    #[test]
+    fn test_append_comments_empty_is_noop() {
+        let mut md = "body\n".to_string();
+        let mut plain = "body\n".to_string();
+        append_comments(&mut md, &mut plain, &[]);
+        assert_eq!(md, "body\n");
+        assert_eq!(plain, "body\n");
+    }
+
+    #[test]
+    fn test_append_comments_separated_by_blank_line() {
+        let mut md = "# Title\n\nSome body.\n".to_string();
+        let mut plain = "Some body.\n".to_string();
+        append_comments(&mut md, &mut plain, &[c("A", "B", "C", false)]);
+        assert!(md.contains("Some body.\n\n# Comments\n"));
+        assert!(plain.contains("Some body.\n\nComments\n"));
+        assert!(md.ends_with("- **source**: C\n"));
+    }
+
+    #[test]
+    fn test_append_comments_empty_body_no_leading_blank() {
+        // Comments-only document: body empty -> section with no leading blank lines.
+        let mut md = String::new();
+        let mut plain = String::new();
+        append_comments(&mut md, &mut plain, &[c("A", "B", "C", false)]);
+        assert!(md.starts_with("# Comments\n"));
+        assert!(plain.starts_with("Comments\n"));
+    }
+
+    #[test]
+    fn test_append_comments_whitespace_only_body_treated_as_empty() {
+        let mut md = "\n\n".to_string();
+        let mut plain = "  \n".to_string();
+        append_comments(&mut md, &mut plain, &[c("A", "B", "C", false)]);
+        assert!(md.starts_with("# Comments\n"));
+        assert!(plain.starts_with("Comments\n"));
+    }
+}

--- a/src/converter/comments.rs
+++ b/src/converter/comments.rs
@@ -40,20 +40,26 @@ pub(crate) struct Comment {
 /// Maximum number of characters retained for a comment's `source` text.
 pub(crate) const SOURCE_CAP: usize = 200;
 
-/// Collapse all runs of whitespace (spaces, tabs, newlines) into single spaces
-/// and trim the ends.
+/// Collapse runs of ASCII whitespace (space, tab, CR, LF, FF) into single
+/// spaces and trim the ends.
 ///
 /// Used to flatten multi-paragraph comment bodies and ranged source text into a
-/// single line suitable for a Markdown list item.
+/// single line suitable for a Markdown list item. Only ASCII whitespace is
+/// collapsed: meaningful non-ASCII spaces (NBSP U+00A0, ideographic space
+/// U+3000, etc.) are content and are preserved verbatim.
 pub(crate) fn collapse_ws(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<_>>().join(" ")
+    s.split(|c: char| c.is_ascii_whitespace())
+        .filter(|seg| !seg.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Truncate `s` to at most `max_chars` Unicode scalar values, appending `…`
 /// when truncation occurs.
 ///
-/// Truncation always lands on a character boundary, so multi-byte characters
-/// (CJK, emoji) are never split mid-byte.
+/// Truncation lands on a Unicode scalar (`char`) boundary, so the result is
+/// always valid UTF-8. Multi-scalar grapheme clusters (e.g. flag or ZWJ emoji)
+/// may be split at that boundary; this affects only the truncated tail.
 pub(crate) fn cap_text(s: &str, max_chars: usize) -> String {
     // `nth(max_chars)` yields the byte index of the character just past the cap
     // (0-indexed), which is exactly the truncation point and always a char
@@ -186,6 +192,16 @@ mod tests {
     #[test]
     fn test_collapse_ws_cjk_preserved() {
         assert_eq!(collapse_ws("한국어\n中文"), "한국어 中文");
+    }
+
+    #[test]
+    fn test_collapse_ws_preserves_non_ascii_spaces() {
+        // NBSP (U+00A0) and ideographic space (U+3000) are content, not layout,
+        // and must survive collapsing (project Unicode-fidelity goal).
+        assert_eq!(collapse_ws("a\u{00A0}b"), "a\u{00A0}b");
+        assert_eq!(collapse_ws("中\u{3000}文"), "中\u{3000}文");
+        // ASCII whitespace around a preserved NBSP still collapses.
+        assert_eq!(collapse_ws("  a\u{00A0}b \n c "), "a\u{00A0}b c");
     }
 
     // ---- cap_text ----

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -1488,7 +1488,10 @@ fn assemble_docx_comments(
     }
 
     // 2. Orphan comments (no anchor), in comments.xml id order (numeric when possible).
-    let mut orphan_ids: Vec<&String> = raw.keys().filter(|id| !anchored_seen.contains(*id)).collect();
+    let mut orphan_ids: Vec<&String> = raw
+        .keys()
+        .filter(|id| !anchored_seen.contains(*id))
+        .collect();
     orphan_ids.sort_by(|a, b| match (a.parse::<u64>(), b.parse::<u64>()) {
         (Ok(x), Ok(y)) => x.cmp(&y),
         _ => a.cmp(b),
@@ -3631,15 +3634,27 @@ mod tests {
             ..Default::default()
         };
         let result = DocxConverter.convert(&data, &options).unwrap();
-        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains("# Comments"),
+            "md: {}",
+            result.markdown
+        );
         assert!(result.markdown.contains("## 1"));
         assert!(
             result
                 .markdown
                 .contains("- **author**: Jane Smith (2024-01-15T09:30:00Z)")
         );
-        assert!(result.markdown.contains("- **comment**: Please revise this."));
-        assert!(result.markdown.contains("- **source**: the quick brown fox"));
+        assert!(
+            result
+                .markdown
+                .contains("- **comment**: Please revise this.")
+        );
+        assert!(
+            result
+                .markdown
+                .contains("- **source**: the quick brown fox")
+        );
         // Body content is preserved above the section.
         assert!(result.markdown.contains("Intro paragraph."));
         let body_pos = result.markdown.find("Intro paragraph.").unwrap();
@@ -3671,7 +3686,11 @@ mod tests {
         };
         let result = DocxConverter.convert(&data, &options).unwrap();
         assert!(result.plain_text.contains("Comments\n"));
-        assert!(result.plain_text.contains("author: Jane Smith (2024-01-15T09:30:00Z)"));
+        assert!(
+            result
+                .plain_text
+                .contains("author: Jane Smith (2024-01-15T09:30:00Z)")
+        );
         assert!(result.plain_text.contains("comment: Revise."));
         assert!(result.plain_text.contains("source: the quick brown fox"));
         // No markdown markers in the appended plain-text section.
@@ -3690,7 +3709,11 @@ mod tests {
             ..Default::default()
         };
         let result = DocxConverter.convert(&data, &options).unwrap();
-        assert!(result.markdown.contains("- **author**: Unknown"), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains("- **author**: Unknown"),
+            "md: {}",
+            result.markdown
+        );
     }
 
     #[test]
@@ -3740,7 +3763,11 @@ mod tests {
         // The source line is capped to 200 x's + ellipsis (the full 300-char run
         // still appears in the body paragraph, so we check the source line only).
         let expected = format!("- **source**: {}…", "x".repeat(200));
-        assert!(result.markdown.contains(&expected), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains(&expected),
+            "md: {}",
+            result.markdown
+        );
         let source_line = result
             .markdown
             .lines()
@@ -3766,9 +3793,17 @@ mod tests {
         let result = DocxConverter.convert(&data, &options).unwrap();
         let anchored = result.markdown.find("Has anchor").unwrap();
         let orphan = result.markdown.find("No anchor").unwrap();
-        assert!(anchored < orphan, "orphan must come last, md: {}", result.markdown);
+        assert!(
+            anchored < orphan,
+            "orphan must come last, md: {}",
+            result.markdown
+        );
         // Orphan's source is empty.
-        assert!(result.markdown.contains("- **comment**: No anchor\n- **source**: \n"));
+        assert!(
+            result
+                .markdown
+                .contains("- **comment**: No anchor\n- **source**: \n")
+        );
     }
 
     #[test]
@@ -3782,14 +3817,16 @@ mod tests {
         );
         let cx = comments_xml(&[
             ("1", "BodyAuthor", "2024-01-01T00:00:00Z", "Body comment"),
-            ("2", "HeaderAuthor", "2024-01-02T00:00:00Z", "Header comment"),
+            (
+                "2",
+                "HeaderAuthor",
+                "2024-01-02T00:00:00Z",
+                "Header comment",
+            ),
         ]);
         let data = build_test_docx_with_parts(
             &doc,
-            &[
-                ("word/comments.xml", &cx),
-                ("word/header1.xml", &header),
-            ],
+            &[("word/comments.xml", &cx), ("word/header1.xml", &header)],
         );
         let options = ConversionOptions {
             extract_comments: true,
@@ -3798,7 +3835,10 @@ mod tests {
         let result = DocxConverter.convert(&data, &options).unwrap();
         let body_c = result.markdown.find("Body comment").unwrap();
         let header_c = result.markdown.find("Header comment").unwrap();
-        assert!(body_c < header_c, "body comment must precede header comment");
+        assert!(
+            body_c < header_c,
+            "body comment must precede header comment"
+        );
         assert!(result.markdown.contains("- **source**: header anchor"));
     }
 

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -26,7 +26,7 @@ use crate::markdown::{
     build_table, build_table_plain, format_heading, format_list_item, format_list_item_plain,
     wrap_formatting,
 };
-use crate::zip_utils::{read_zip_bytes, read_zip_text};
+use crate::zip_utils::{read_zip_bytes, read_zip_text, read_zip_text_lossy};
 
 /// Converts DOCX files to Markdown.
 pub struct DocxConverter;
@@ -1182,10 +1182,17 @@ fn parse_comments_xml(xml: &str) -> HashMap<String, RawComment> {
     let mut last_para_id: Option<String> = None;
     let mut para_count: usize = 0;
     let mut in_text = false;
+    // Depth of nested tables; w14:paraId is only meaningful on the comment's
+    // top-level paragraphs (commentsExtended threads on the last of those), so
+    // paraIds inside table cells must be ignored.
+    let mut table_depth: u32 = 0;
 
     loop {
         match reader.read_event() {
-            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+            // Only Event::Start sets in_text: a self-closing `<w:t/>` arrives as
+            // Event::Empty with no matching End, so handling it here would leave
+            // in_text stuck true and leak later text into the body.
+            Ok(Event::Start(ref e)) => {
                 let local = e.local_name();
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
                 match local_str {
@@ -1196,36 +1203,53 @@ fn parse_comments_xml(xml: &str) -> HashMap<String, RawComment> {
                         cur_body = String::new();
                         last_para_id = None;
                         para_count = 0;
-                        for attr in e.attributes().flatten() {
-                            let k = attr.key.local_name();
-                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                            let v = String::from_utf8_lossy(&attr.value).to_string();
-                            match k {
-                                "id" => cur_id = Some(v),
-                                "author" => cur_author = v,
-                                "date" => cur_date = v,
-                                _ => {}
-                            }
+                        table_depth = 0;
+                        if let Some(v) =
+                            crate::converter::ooxml_utils::attr_value_unescaped(e, "id")
+                        {
+                            cur_id = Some(v);
+                        }
+                        if let Some(v) =
+                            crate::converter::ooxml_utils::attr_value_unescaped(e, "author")
+                        {
+                            cur_author = v;
+                        }
+                        if let Some(v) =
+                            crate::converter::ooxml_utils::attr_value_unescaped(e, "date")
+                        {
+                            cur_date = v;
                         }
                     }
+                    "tbl" if cur_id.is_some() => table_depth += 1,
                     "p" if cur_id.is_some() => {
                         // Separate paragraphs with a newline (collapsed later).
                         if para_count > 0 {
                             cur_body.push('\n');
                         }
                         para_count += 1;
-                        // Capture w14:paraId (last one wins).
-                        for attr in e.attributes().flatten() {
-                            let k = attr.key.local_name();
-                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                            if k == "paraId" {
-                                last_para_id =
-                                    Some(String::from_utf8_lossy(&attr.value).to_string());
-                            }
+                        // Capture w14:paraId of top-level paragraphs only (last wins).
+                        if table_depth == 0
+                            && let Some(v) =
+                                crate::converter::ooxml_utils::attr_value_unescaped(e, "paraId")
+                        {
+                            last_para_id = Some(v);
                         }
                     }
                     "t" if cur_id.is_some() => in_text = true,
                     _ => {}
+                }
+            }
+            Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                // A self-closing top-level `<w:p .../>` still counts paraId.
+                if local_str == "p"
+                    && cur_id.is_some()
+                    && table_depth == 0
+                    && let Some(v) =
+                        crate::converter::ooxml_utils::attr_value_unescaped(e, "paraId")
+                {
+                    last_para_id = Some(v);
                 }
             }
             Ok(Event::Text(ref e)) if in_text => {
@@ -1236,6 +1260,7 @@ fn parse_comments_xml(xml: &str) -> HashMap<String, RawComment> {
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
                 match local_str {
                     "t" => in_text = false,
+                    "tbl" if table_depth > 0 => table_depth -= 1,
                     "comment" => {
                         if let Some(id) = cur_id.take() {
                             comments.insert(
@@ -1317,14 +1342,72 @@ fn collect_ranges_in_part(xml: &str) -> (Vec<String>, HashMap<String, String>) {
     // Set of currently-open range ids; text events append to all of them.
     let mut open: HashSet<String> = HashSet::new();
 
-    // Skip mc:Choice branches (mirror body behavior).
+    // Skip mc:Choice branches for CONTENT (mirror body behavior), but range
+    // markers are still honored inside them (see below).
     let mut in_mc_choice = false;
     let mut mc_choice_depth: u32 = 0;
+    // Text is only captured inside a run, matching the body parser — a loose
+    // `<w:t>` outside `<w:r>` is not rendered, so it must not appear in source.
+    let mut in_run = false;
     let mut in_text = false;
 
-    let note_id = |order: &mut Vec<String>, seen: &mut HashSet<String>, id: String| {
-        if seen.insert(id.clone()) {
-            order.push(id);
+    // Per-range byte bound: a malformed range that is never closed (missing or
+    // misplaced commentRangeEnd) must not absorb the whole part. 4 bytes/char
+    // guarantees at least SOURCE_CAP chars survive for the later char-cap.
+    let cap_bytes = comments::SOURCE_CAP.saturating_mul(4);
+
+    // Append `s` to a range buffer, never exceeding `cap_bytes` total; the slice
+    // is cut on a char boundary so the buffer stays valid UTF-8.
+    let push_capped = |buf: &mut String, s: &str| {
+        if buf.len() >= cap_bytes {
+            return;
+        }
+        let mut room = cap_bytes - buf.len();
+        if room >= s.len() {
+            buf.push_str(s);
+        } else {
+            while room > 0 && !s.is_char_boundary(room) {
+                room -= 1;
+            }
+            buf.push_str(&s[..room]);
+        }
+    };
+
+    // Handle a comment range/reference marker. Returns true if `local_str` was a
+    // marker. Markers are honored even inside a skipped mc:Choice branch so that
+    // a range whose end lands there still closes (rather than leaking forever).
+    let handle_marker = |local_str: &str,
+                         e: &quick_xml::events::BytesStart,
+                         order: &mut Vec<String>,
+                         seen: &mut HashSet<String>,
+                         open: &mut HashSet<String>| {
+        // Record an id in first-appearance order.
+        let note_id = |order: &mut Vec<String>, seen: &mut HashSet<String>, id: String| {
+            if seen.insert(id.clone()) {
+                order.push(id);
+            }
+        };
+        match local_str {
+            "commentRangeStart" => {
+                if let Some(id) = range_id(e) {
+                    note_id(order, seen, id.clone());
+                    open.insert(id);
+                }
+                true
+            }
+            "commentRangeEnd" => {
+                if let Some(id) = range_id(e) {
+                    open.remove(&id);
+                }
+                true
+            }
+            "commentReference" => {
+                if let Some(id) = range_id(e) {
+                    note_id(order, seen, id);
+                }
+                true
+            }
+            _ => false,
         }
     };
 
@@ -1333,6 +1416,9 @@ fn collect_ranges_in_part(xml: &str) -> (Vec<String>, HashMap<String, String>) {
             Ok(Event::Start(ref e)) => {
                 let local = e.local_name();
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if handle_marker(local_str, e, &mut order, &mut seen, &mut open) {
+                    continue;
+                }
                 if in_mc_choice {
                     mc_choice_depth += 1;
                     continue;
@@ -1342,61 +1428,30 @@ fn collect_ranges_in_part(xml: &str) -> (Vec<String>, HashMap<String, String>) {
                         in_mc_choice = true;
                         mc_choice_depth = 1;
                     }
-                    "commentRangeStart" => {
-                        if let Some(id) = range_id(e) {
-                            note_id(&mut order, &mut seen, id.clone());
-                            open.insert(id);
-                        }
-                    }
-                    "commentRangeEnd" => {
-                        if let Some(id) = range_id(e) {
-                            open.remove(&id);
-                        }
-                    }
-                    "commentReference" => {
-                        if let Some(id) = range_id(e) {
-                            note_id(&mut order, &mut seen, id);
-                        }
-                    }
+                    "r" => in_run = true,
                     "t" => in_text = true,
                     _ => {}
                 }
             }
             Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if handle_marker(local_str, e, &mut order, &mut seen, &mut open) {
+                    continue;
+                }
                 if in_mc_choice {
                     continue;
                 }
-                let local = e.local_name();
-                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
-                match local_str {
-                    "commentRangeStart" => {
-                        if let Some(id) = range_id(e) {
-                            note_id(&mut order, &mut seen, id.clone());
-                            open.insert(id);
-                        }
+                if local_str == "br" && in_run && !open.is_empty() {
+                    for id in &open {
+                        push_capped(text.entry(id.clone()).or_default(), " ");
                     }
-                    "commentRangeEnd" => {
-                        if let Some(id) = range_id(e) {
-                            open.remove(&id);
-                        }
-                    }
-                    "commentReference" => {
-                        if let Some(id) = range_id(e) {
-                            note_id(&mut order, &mut seen, id);
-                        }
-                    }
-                    "br" if !open.is_empty() => {
-                        for id in &open {
-                            text.entry(id.clone()).or_default().push(' ');
-                        }
-                    }
-                    _ => {}
                 }
             }
-            Ok(Event::Text(ref e)) if in_text && !open.is_empty() => {
-                let t = e.unescape().unwrap_or_default().to_string();
+            Ok(Event::Text(ref e)) if in_text && in_run && !open.is_empty() => {
+                let t = e.unescape().unwrap_or_default();
                 for id in &open {
-                    text.entry(id.clone()).or_default().push_str(&t);
+                    push_capped(text.entry(id.clone()).or_default(), &t);
                 }
             }
             Ok(Event::End(ref e)) => {
@@ -1409,8 +1464,13 @@ fn collect_ranges_in_part(xml: &str) -> (Vec<String>, HashMap<String, String>) {
                     }
                     continue;
                 }
-                if local_str == "t" {
-                    in_text = false;
+                match local_str {
+                    "t" => in_text = false,
+                    "r" => {
+                        in_run = false;
+                        in_text = false;
+                    }
+                    _ => {}
                 }
             }
             Ok(Event::Eof) => break,
@@ -1492,9 +1552,16 @@ fn assemble_docx_comments(
         .keys()
         .filter(|id| !anchored_seen.contains(*id))
         .collect();
-    orphan_ids.sort_by(|a, b| match (a.parse::<u64>(), b.parse::<u64>()) {
-        (Ok(x), Ok(y)) => x.cmp(&y),
-        _ => a.cmp(b),
+    // Sort by (numeric value, original string) so the comparator is a total
+    // order even with a mix of numeric and non-numeric ids: all parseable ids
+    // sort numerically and ahead of any non-numeric ones (None > Some), with the
+    // string as a stable tiebreaker.
+    orphan_ids.sort_by_key(|id| {
+        (
+            id.parse::<u64>().ok().is_none(),
+            id.parse::<u64>().ok(),
+            (*id).clone(),
+        )
     });
     for id in orphan_ids {
         if let Some(rc) = raw.get(id) {
@@ -1536,7 +1603,9 @@ fn extract_docx_comments(
     body_xml: &str,
     warnings: &mut Vec<ConversionWarning>,
 ) -> Result<Vec<Comment>, ConvertError> {
-    let comments_xml = match read_zip_text(archive, "word/comments.xml")? {
+    // Comment parts are read leniently (lossy UTF-8): a malformed sub-part must
+    // not abort the whole document conversion (best-effort principle).
+    let comments_xml = match read_zip_text_lossy(archive, "word/comments.xml")? {
         Some(xml) => xml,
         None => return Ok(Vec::new()),
     };
@@ -1545,7 +1614,7 @@ fn extract_docx_comments(
         return Ok(Vec::new());
     }
 
-    let reply_para_ids = match read_zip_text(archive, "word/commentsExtended.xml")? {
+    let reply_para_ids = match read_zip_text_lossy(archive, "word/commentsExtended.xml")? {
         Some(xml) => parse_comments_extended(&xml),
         None => HashSet::new(),
     };
@@ -1572,12 +1641,12 @@ fn extract_docx_comments(
     let mut part_results: Vec<(Vec<String>, HashMap<String, String>)> = Vec::new();
     part_results.push(collect_ranges_in_part(body_xml));
     for path in headers.iter().chain(footers.iter()) {
-        if let Some(xml) = read_zip_text(archive, path)? {
+        if let Some(xml) = read_zip_text_lossy(archive, path)? {
             part_results.push(collect_ranges_in_part(&xml));
         }
     }
     for path in ["word/footnotes.xml", "word/endnotes.xml"] {
-        if let Some(xml) = read_zip_text(archive, path)? {
+        if let Some(xml) = read_zip_text_lossy(archive, path)? {
             part_results.push(collect_ranges_in_part(&xml));
         }
     }
@@ -3483,6 +3552,20 @@ mod tests {
     /// Build a DOCX with an arbitrary set of extra parts (e.g. comments.xml,
     /// headers, footnotes) in addition to document.xml.
     fn build_test_docx_with_parts(document_xml: &str, extra_parts: &[(&str, &str)]) -> Vec<u8> {
+        let byte_parts: Vec<(&str, Vec<u8>)> = extra_parts
+            .iter()
+            .map(|(p, c)| (*p, c.as_bytes().to_vec()))
+            .collect();
+        let refs: Vec<(&str, &[u8])> = byte_parts.iter().map(|(p, c)| (*p, c.as_slice())).collect();
+        build_test_docx_with_parts_bytes(document_xml, &refs)
+    }
+
+    /// Like `build_test_docx_with_parts`, but extra parts are raw bytes (so a
+    /// part can contain invalid UTF-8 for best-effort/lenient-decode tests).
+    fn build_test_docx_with_parts_bytes(
+        document_xml: &str,
+        extra_parts: &[(&str, &[u8])],
+    ) -> Vec<u8> {
         use std::io::Write;
         use zip::ZipWriter;
         use zip::write::SimpleFileOptions;
@@ -3506,7 +3589,7 @@ mod tests {
 
         for (path, content) in extra_parts {
             zip.start_file(*path, opts).unwrap();
-            zip.write_all(content.as_bytes()).unwrap();
+            zip.write_all(content).unwrap();
         }
 
         let cursor = zip.finish().unwrap();
@@ -3879,5 +3962,119 @@ mod tests {
         };
         let result = DocxConverter.convert(&data, &options).unwrap();
         assert!(!result.markdown.contains("# Comments"));
+    }
+
+    // ---- Regression tests for review findings ----
+
+    fn extract_opts() -> ConversionOptions {
+        ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_parse_comments_xml_self_closing_t_no_leak() {
+        // Finding 5: a self-closing <w:t/> (Empty event) must not leave in_text
+        // stuck true and capture stray text from later in the same comment.
+        let cx = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="1" w:author="A"><w:p><w:r><w:t/></w:r><w:r><w:t>real</w:t></w:r></w:p></w:comment></w:comments>"#;
+        let parsed = parse_comments_xml(cx);
+        assert_eq!(parsed.get("1").unwrap().body, "real");
+    }
+
+    #[test]
+    fn test_parse_comments_xml_unescapes_author() {
+        // Finding 8: author/date attributes must be XML-unescaped.
+        let cx = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="1" w:author="R&amp;D &lt;Team&gt;"><w:p><w:r><w:t>x</w:t></w:r></w:p></w:comment></w:comments>"#;
+        let parsed = parse_comments_xml(cx);
+        assert_eq!(parsed.get("1").unwrap().author, "R&D <Team>");
+    }
+
+    #[test]
+    fn test_parse_comments_xml_para_id_ignores_table_cells() {
+        // Finding 9: w14:paraId must come from the last TOP-LEVEL paragraph, not
+        // a nested table-cell paragraph.
+        let cx = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:comment w:id="1" w:author="A"><w:p w14:paraId="TOP">text</w:p><w:tbl><w:tr><w:tc><w:p w14:paraId="CELL"><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:comment></w:comments>"#;
+        let parsed = parse_comments_xml(cx);
+        assert_eq!(parsed.get("1").unwrap().para_id.as_deref(), Some("TOP"));
+    }
+
+    #[test]
+    fn test_collect_ranges_end_inside_mc_choice_closes() {
+        // Findings 1/3: a commentRangeEnd buried in a skipped mc:Choice must still
+        // close the range, so later text does not leak into the source.
+        let body = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>anchor</w:t></w:r><mc:AlternateContent><mc:Choice Requires="wps"><w:commentRangeEnd w:id="1"/></mc:Choice><mc:Fallback><w:r><w:t>fb</w:t></w:r></mc:Fallback></mc:AlternateContent><w:r><w:commentReference w:id="1"/></w:r></w:p><w:p><w:r><w:t>UNRELATED LATER TEXT</w:t></w:r></w:p>"#,
+        );
+        let (_order, text) = collect_ranges_in_part(&body);
+        let src = text.get("1").cloned().unwrap_or_default();
+        assert!(src.contains("anchor"), "src: {src}");
+        assert!(
+            !src.contains("UNRELATED"),
+            "range leaked past its end: {src}"
+        );
+    }
+
+    #[test]
+    fn test_collect_ranges_unclosed_range_is_bounded() {
+        // Finding 1: a range with no commentRangeEnd at all must not absorb an
+        // unbounded amount of the part (bounded to SOURCE_CAP*4 bytes).
+        let huge = "x".repeat(5000);
+        let body = wrap_body(&format!(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>anchor</w:t></w:r><w:r><w:commentReference w:id="1"/></w:r></w:p><w:p><w:r><w:t>{huge}</w:t></w:r></w:p>"#
+        ));
+        let (_order, text) = collect_ranges_in_part(&body);
+        let src = text.get("1").cloned().unwrap_or_default();
+        // Bounded well under the 5000-char tail (cap is SOURCE_CAP*4 = 800 bytes).
+        assert!(
+            src.len() <= comments::SOURCE_CAP * 4 + 16,
+            "unbounded: {} bytes",
+            src.len()
+        );
+    }
+
+    #[test]
+    fn test_collect_ranges_ignores_loose_text_outside_run() {
+        // Finding 6: text outside a <w:r> is not rendered in the body, so it must
+        // not appear in the commented-on source either.
+        let body = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:t>loose no run</w:t><w:r><w:t>real</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        );
+        let (_order, text) = collect_ranges_in_part(&body);
+        let src = text.get("1").cloned().unwrap_or_default();
+        assert_eq!(
+            src, "real",
+            "loose text outside a run leaked into source: {src}"
+        );
+    }
+
+    #[test]
+    fn test_docx_comments_author_entity_end_to_end() {
+        // Finding 8 end-to-end: "R&D" renders as R&D, not R&amp;D.
+        let doc = body_with_comment_1();
+        let cx = comments_xml(&[("1", "R&amp;D Team", "2024-01-01T00:00:00Z", "note")]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let result = DocxConverter.convert(&data, &extract_opts()).unwrap();
+        assert!(
+            result.markdown.contains("- **author**: R&D Team"),
+            "md: {}",
+            result.markdown
+        );
+        assert!(!result.markdown.contains("R&amp;D"));
+    }
+
+    #[test]
+    fn test_docx_comments_malformed_part_does_not_abort() {
+        // Finding 4: a non-UTF-8 comments.xml must not abort conversion; the body
+        // still converts (best-effort).
+        let doc = wrap_body(&para("Body survives."));
+        // comments.xml referencing valid structure but with an invalid byte.
+        let mut cx = comments_xml(&[("1", "A", "2024-01-01T00:00:00Z", "ok")]).into_bytes();
+        cx.push(0xFF); // invalid UTF-8 trailing byte
+        let data = build_test_docx_with_parts_bytes(&doc, &[("word/comments.xml", &cx)]);
+        let result = DocxConverter.convert(&data, &extract_opts()).unwrap();
+        assert!(result.markdown.contains("Body survives."));
+        // Lossy decode still recovers the well-formed comment.
+        assert!(result.markdown.contains("# Comments"));
     }
 }

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -6,13 +6,14 @@
 //! `v:textbox` / `w:txbxContent`). Text boxes wrapped in `mc:AlternateContent` are
 //! handled by skipping the `mc:Choice` branch and processing `mc:Fallback` (VML).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 
 use quick_xml::Reader;
 use quick_xml::events::Event;
 use zip::ZipArchive;
 
+use crate::converter::comments::{self, Comment};
 use crate::converter::ooxml_utils::{
     ImageInfo, PendingImageResolution, Relationship, parse_relationships,
     resolve_image_placeholders, resolve_relative_to_file,
@@ -1152,18 +1153,454 @@ fn finalize_paragraph(
     }
 }
 
+// ---- Comment extraction ----
+
+/// A raw comment parsed from `word/comments.xml`, before assembly into a
+/// rendered [`Comment`].
+#[derive(Debug, Clone)]
+struct RawComment {
+    author: String,
+    date: String,
+    body: String,
+    /// The `w14:paraId` of the comment's last paragraph, used to link a comment
+    /// to its reply metadata in `commentsExtended.xml`.
+    para_id: Option<String>,
+}
+
+/// Parse `word/comments.xml` into a map from comment id to its raw content.
+///
+/// Captures `w:author`, `w:date`, the concatenated body text (paragraphs joined
+/// by newline, later collapsed), and the `w14:paraId` of the final paragraph.
+fn parse_comments_xml(xml: &str) -> HashMap<String, RawComment> {
+    let mut reader = Reader::from_str(xml);
+    let mut comments: HashMap<String, RawComment> = HashMap::new();
+
+    let mut cur_id: Option<String> = None;
+    let mut cur_author = String::new();
+    let mut cur_date = String::new();
+    let mut cur_body = String::new();
+    let mut last_para_id: Option<String> = None;
+    let mut para_count: usize = 0;
+    let mut in_text = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "comment" => {
+                        cur_id = None;
+                        cur_author = String::new();
+                        cur_date = String::new();
+                        cur_body = String::new();
+                        last_para_id = None;
+                        para_count = 0;
+                        for attr in e.attributes().flatten() {
+                            let k = attr.key.local_name();
+                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                            let v = String::from_utf8_lossy(&attr.value).to_string();
+                            match k {
+                                "id" => cur_id = Some(v),
+                                "author" => cur_author = v,
+                                "date" => cur_date = v,
+                                _ => {}
+                            }
+                        }
+                    }
+                    "p" if cur_id.is_some() => {
+                        // Separate paragraphs with a newline (collapsed later).
+                        if para_count > 0 {
+                            cur_body.push('\n');
+                        }
+                        para_count += 1;
+                        // Capture w14:paraId (last one wins).
+                        for attr in e.attributes().flatten() {
+                            let k = attr.key.local_name();
+                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                            if k == "paraId" {
+                                last_para_id =
+                                    Some(String::from_utf8_lossy(&attr.value).to_string());
+                            }
+                        }
+                    }
+                    "t" if cur_id.is_some() => in_text = true,
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(ref e)) if in_text => {
+                cur_body.push_str(&e.unescape().unwrap_or_default());
+            }
+            Ok(Event::End(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "t" => in_text = false,
+                    "comment" => {
+                        if let Some(id) = cur_id.take() {
+                            comments.insert(
+                                id,
+                                RawComment {
+                                    author: std::mem::take(&mut cur_author),
+                                    date: std::mem::take(&mut cur_date),
+                                    body: std::mem::take(&mut cur_body),
+                                    para_id: last_para_id.take(),
+                                },
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    comments
+}
+
+/// Parse `word/commentsExtended.xml`, returning the set of `w15:paraId` values
+/// that are replies (i.e., have a `w15:paraIdParent`).
+fn parse_comments_extended(xml: &str) -> HashSet<String> {
+    let mut reader = Reader::from_str(xml);
+    let mut reply_para_ids: HashSet<String> = HashSet::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if local_str == "commentEx" {
+                    let mut para_id: Option<String> = None;
+                    let mut has_parent = false;
+                    for attr in e.attributes().flatten() {
+                        let k = attr.key.local_name();
+                        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                        match k {
+                            "paraId" => {
+                                para_id = Some(String::from_utf8_lossy(&attr.value).to_string());
+                            }
+                            "paraIdParent" => has_parent = true,
+                            _ => {}
+                        }
+                    }
+                    if has_parent && let Some(pid) = para_id {
+                        reply_para_ids.insert(pid);
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    reply_para_ids
+}
+
+/// Collect commented-on text ranges from a single content part (document body,
+/// header, footer, footnotes, or endnotes).
+///
+/// Returns the comment ids in first-appearance order (keyed on whichever of
+/// `commentRangeStart` or `commentReference` appears first) and a map from id to
+/// the concatenated source text inside its range. Mirrors the body's extraction
+/// rules: skips `mc:Choice` branches, includes text-box/table text, and takes
+/// hyperlink display text (images contribute nothing).
+fn collect_ranges_in_part(xml: &str) -> (Vec<String>, HashMap<String, String>) {
+    let mut reader = Reader::from_str(xml);
+
+    let mut order: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut text: HashMap<String, String> = HashMap::new();
+    // Set of currently-open range ids; text events append to all of them.
+    let mut open: HashSet<String> = HashSet::new();
+
+    // Skip mc:Choice branches (mirror body behavior).
+    let mut in_mc_choice = false;
+    let mut mc_choice_depth: u32 = 0;
+    let mut in_text = false;
+
+    let note_id = |order: &mut Vec<String>, seen: &mut HashSet<String>, id: String| {
+        if seen.insert(id.clone()) {
+            order.push(id);
+        }
+    };
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if in_mc_choice {
+                    mc_choice_depth += 1;
+                    continue;
+                }
+                match local_str {
+                    "Choice" => {
+                        in_mc_choice = true;
+                        mc_choice_depth = 1;
+                    }
+                    "commentRangeStart" => {
+                        if let Some(id) = range_id(e) {
+                            note_id(&mut order, &mut seen, id.clone());
+                            open.insert(id);
+                        }
+                    }
+                    "commentRangeEnd" => {
+                        if let Some(id) = range_id(e) {
+                            open.remove(&id);
+                        }
+                    }
+                    "commentReference" => {
+                        if let Some(id) = range_id(e) {
+                            note_id(&mut order, &mut seen, id);
+                        }
+                    }
+                    "t" => in_text = true,
+                    _ => {}
+                }
+            }
+            Ok(Event::Empty(ref e)) => {
+                if in_mc_choice {
+                    continue;
+                }
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "commentRangeStart" => {
+                        if let Some(id) = range_id(e) {
+                            note_id(&mut order, &mut seen, id.clone());
+                            open.insert(id);
+                        }
+                    }
+                    "commentRangeEnd" => {
+                        if let Some(id) = range_id(e) {
+                            open.remove(&id);
+                        }
+                    }
+                    "commentReference" => {
+                        if let Some(id) = range_id(e) {
+                            note_id(&mut order, &mut seen, id);
+                        }
+                    }
+                    "br" if !open.is_empty() => {
+                        for id in &open {
+                            text.entry(id.clone()).or_default().push(' ');
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(ref e)) if in_text && !open.is_empty() => {
+                let t = e.unescape().unwrap_or_default().to_string();
+                for id in &open {
+                    text.entry(id.clone()).or_default().push_str(&t);
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if in_mc_choice {
+                    mc_choice_depth -= 1;
+                    if mc_choice_depth == 0 {
+                        in_mc_choice = false;
+                    }
+                    continue;
+                }
+                if local_str == "t" {
+                    in_text = false;
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    (order, text)
+}
+
+/// Extract the `w:id` attribute from a comment range/reference element.
+fn range_id(e: &quick_xml::events::BytesStart) -> Option<String> {
+    for attr in e.attributes().flatten() {
+        let k = attr.key.local_name();
+        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+        if k == "id" {
+            return Some(String::from_utf8_lossy(&attr.value).to_string());
+        }
+    }
+    None
+}
+
+/// Assemble the final ordered list of [`Comment`]s for a DOCX document.
+///
+/// `part_orders` holds the per-part `(order, text)` results in the fixed scan
+/// sequence (body, headers, footers, footnotes, endnotes). Comments are ordered
+/// by first anchor appearance across parts (first part wins on duplicate ids);
+/// comments with no anchor anywhere are appended last in `comments.xml` order.
+/// A warning is pushed for any anchor referencing an unknown comment id.
+fn assemble_docx_comments(
+    raw: &HashMap<String, RawComment>,
+    reply_para_ids: &HashSet<String>,
+    part_results: &[(Vec<String>, HashMap<String, String>)],
+    warnings: &mut Vec<ConversionWarning>,
+) -> Vec<Comment> {
+    let mut anchored_order: Vec<String> = Vec::new();
+    let mut anchored_seen: HashSet<String> = HashSet::new();
+    let mut source_by_id: HashMap<String, String> = HashMap::new();
+
+    for (order, text) in part_results {
+        for id in order {
+            if anchored_seen.insert(id.clone()) {
+                anchored_order.push(id.clone());
+            }
+            // Merge discontinuous ranges for the same id across parts with " … ".
+            if let Some(t) = text.get(id)
+                && !t.is_empty()
+            {
+                match source_by_id.get_mut(id) {
+                    Some(existing) => {
+                        existing.push_str(" … ");
+                        existing.push_str(t);
+                    }
+                    None => {
+                        source_by_id.insert(id.clone(), t.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let mut result: Vec<Comment> = Vec::new();
+
+    // 1. Anchored comments, in appearance order.
+    for id in &anchored_order {
+        match raw.get(id) {
+            Some(rc) => result.push(build_comment(rc, reply_para_ids, source_by_id.get(id))),
+            None => warnings.push(ConversionWarning {
+                code: WarningCode::MalformedSegment,
+                message: format!("comment range references unknown comment id '{id}'"),
+                location: Some(id.clone()),
+            }),
+        }
+    }
+
+    // 2. Orphan comments (no anchor), in comments.xml id order (numeric when possible).
+    let mut orphan_ids: Vec<&String> = raw.keys().filter(|id| !anchored_seen.contains(*id)).collect();
+    orphan_ids.sort_by(|a, b| match (a.parse::<u64>(), b.parse::<u64>()) {
+        (Ok(x), Ok(y)) => x.cmp(&y),
+        _ => a.cmp(b),
+    });
+    for id in orphan_ids {
+        if let Some(rc) = raw.get(id) {
+            result.push(build_comment(rc, reply_para_ids, None));
+        }
+    }
+
+    result
+}
+
+/// Build a rendered [`Comment`] from a raw comment and optional source text.
+fn build_comment(
+    rc: &RawComment,
+    reply_para_ids: &HashSet<String>,
+    source: Option<&String>,
+) -> Comment {
+    let is_reply = rc
+        .para_id
+        .as_ref()
+        .is_some_and(|pid| reply_para_ids.contains(pid));
+    let source = source
+        .map(|s| comments::cap_text(&comments::collapse_ws(s), comments::SOURCE_CAP))
+        .unwrap_or_default();
+    Comment {
+        author: comments::format_author(&rc.author, &rc.date),
+        body: comments::collapse_ws(&rc.body),
+        source,
+        is_reply,
+    }
+}
+
+/// Read all DOCX comments for a document, scanning the body and any
+/// headers/footers/footnotes/endnotes for commented-on text ranges.
+///
+/// Returns an empty vec when there are no comments. `body_xml` is the already
+/// in-memory `word/document.xml`; other parts are read from `archive`.
+fn extract_docx_comments(
+    archive: &mut ZipArchive<Cursor<&[u8]>>,
+    body_xml: &str,
+    warnings: &mut Vec<ConversionWarning>,
+) -> Result<Vec<Comment>, ConvertError> {
+    let comments_xml = match read_zip_text(archive, "word/comments.xml")? {
+        Some(xml) => xml,
+        None => return Ok(Vec::new()),
+    };
+    let raw = parse_comments_xml(&comments_xml);
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let reply_para_ids = match read_zip_text(archive, "word/commentsExtended.xml")? {
+        Some(xml) => parse_comments_extended(&xml),
+        None => HashSet::new(),
+    };
+
+    // Discover extra content parts in fixed-category order: headers, footers,
+    // then footnotes/endnotes. Within a category, sort by filename.
+    let names: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index_raw(i).ok().map(|f| f.name().to_string()))
+        .collect();
+    let mut headers: Vec<String> = names
+        .iter()
+        .filter(|n| n.starts_with("word/header") && n.ends_with(".xml"))
+        .cloned()
+        .collect();
+    headers.sort();
+    let mut footers: Vec<String> = names
+        .iter()
+        .filter(|n| n.starts_with("word/footer") && n.ends_with(".xml"))
+        .cloned()
+        .collect();
+    footers.sort();
+
+    // Fixed scan order: body, headers, footers, footnotes, endnotes.
+    let mut part_results: Vec<(Vec<String>, HashMap<String, String>)> = Vec::new();
+    part_results.push(collect_ranges_in_part(body_xml));
+    for path in headers.iter().chain(footers.iter()) {
+        if let Some(xml) = read_zip_text(archive, path)? {
+            part_results.push(collect_ranges_in_part(&xml));
+        }
+    }
+    for path in ["word/footnotes.xml", "word/endnotes.xml"] {
+        if let Some(xml) = read_zip_text(archive, path)? {
+            part_results.push(collect_ranges_in_part(&xml));
+        }
+    }
+
+    Ok(assemble_docx_comments(
+        &raw,
+        &reply_para_ids,
+        &part_results,
+        warnings,
+    ))
+}
+
 // ---- Internal conversion (parse + image extraction, no resolution) ----
 
 impl DocxConverter {
     /// Parse the document and extract images without resolving placeholders.
     ///
-    /// Returns the conversion result (with unresolved placeholders in markdown)
-    /// and pending image data for later resolution (sync or async).
+    /// Returns the conversion result (with unresolved placeholders in markdown),
+    /// pending image data for later resolution (sync or async), and any extracted
+    /// comments (empty unless `options.extract_comments` is set). Comments are
+    /// appended to the output by the caller, after image placeholders resolve.
     pub(crate) fn convert_inner(
         &self,
         data: &[u8],
         options: &ConversionOptions,
-    ) -> Result<(ConversionResult, PendingImageResolution), ConvertError> {
+    ) -> Result<(ConversionResult, PendingImageResolution, Vec<Comment>), ConvertError> {
         let cursor = Cursor::new(data);
         let mut archive = ZipArchive::new(cursor)?;
 
@@ -1243,6 +1680,13 @@ impl DocxConverter {
             }
         }
 
+        // 6. Extract comments if requested (DOCX body + headers/footers/notes).
+        let doc_comments = if options.extract_comments {
+            extract_docx_comments(&mut archive, &document_xml, &mut warnings)?
+        } else {
+            Vec::new()
+        };
+
         let result = ConversionResult {
             markdown,
             plain_text,
@@ -1256,7 +1700,7 @@ impl DocxConverter {
             bytes: image_bytes_map,
         };
 
-        Ok((result, pending))
+        Ok((result, pending, doc_comments))
     }
 }
 
@@ -1272,7 +1716,7 @@ impl Converter for DocxConverter {
         data: &[u8],
         options: &ConversionOptions,
     ) -> Result<ConversionResult, ConvertError> {
-        let (mut result, pending) = self.convert_inner(data, options)?;
+        let (mut result, pending, doc_comments) = self.convert_inner(data, options)?;
         resolve_image_placeholders(
             &mut result.markdown,
             &mut result.plain_text,
@@ -1281,6 +1725,7 @@ impl Converter for DocxConverter {
             options.image_describer.as_deref(),
             &mut result.warnings,
         );
+        comments::append_comments(&mut result.markdown, &mut result.plain_text, &doc_comments);
         Ok(result)
     }
 }
@@ -3028,5 +3473,371 @@ mod tests {
             "expected empty output, got: {}",
             result.markdown
         );
+    }
+
+    // ---- Comment extraction tests ----
+
+    /// Build a DOCX with an arbitrary set of extra parts (e.g. comments.xml,
+    /// headers, footnotes) in addition to document.xml.
+    fn build_test_docx_with_parts(document_xml: &str, extra_parts: &[(&str, &str)]) -> Vec<u8> {
+        use std::io::Write;
+        use zip::ZipWriter;
+        use zip::write::SimpleFileOptions;
+
+        let buf = Vec::new();
+        let mut zip = ZipWriter::new(Cursor::new(buf));
+        let opts = SimpleFileOptions::default();
+
+        let ct = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(ct.as_bytes()).unwrap();
+
+        zip.start_file("_rels/.rels", opts).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+        )
+        .unwrap();
+
+        zip.start_file("word/document.xml", opts).unwrap();
+        zip.write_all(document_xml.as_bytes()).unwrap();
+
+        for (path, content) in extra_parts {
+            zip.start_file(*path, opts).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+
+        let cursor = zip.finish().unwrap();
+        cursor.into_inner()
+    }
+
+    /// Build a minimal `word/comments.xml` from (id, author, date, body) tuples.
+    /// Each comment's single paragraph carries a `w14:paraId` equal to `pid_<id>`.
+    fn comments_xml(entries: &[(&str, &str, &str, &str)]) -> String {
+        let mut s = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">"#,
+        );
+        for (id, author, date, body) in entries {
+            s.push_str(&format!(
+                r#"<w:comment w:id="{id}" w:author="{author}" w:date="{date}"><w:p w14:paraId="pid_{id}"><w:r><w:t xml:space="preserve">{body}</w:t></w:r></w:p></w:comment>"#
+            ));
+        }
+        s.push_str("</w:comments>");
+        s
+    }
+
+    // -- unit: parse_comments_xml --
+
+    #[test]
+    fn test_parse_comments_xml_basic() {
+        let xml = comments_xml(&[(
+            "1",
+            "Jane Smith",
+            "2024-01-15T09:30:00Z",
+            "Please revise this.",
+        )]);
+        let parsed = parse_comments_xml(&xml);
+        let c = parsed.get("1").expect("comment 1");
+        assert_eq!(c.author, "Jane Smith");
+        assert_eq!(c.date, "2024-01-15T09:30:00Z");
+        assert_eq!(c.body, "Please revise this.");
+        assert_eq!(c.para_id.as_deref(), Some("pid_1"));
+    }
+
+    #[test]
+    fn test_parse_comments_xml_no_author_empty() {
+        let xml = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="3"><w:p><w:r><w:t>Body</w:t></w:r></w:p></w:comment></w:comments>"#;
+        let parsed = parse_comments_xml(xml);
+        let c = parsed.get("3").expect("comment 3");
+        assert_eq!(c.author, "");
+        assert_eq!(c.body, "Body");
+    }
+
+    #[test]
+    fn test_parse_comments_xml_multi_paragraph_joined() {
+        let xml = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="1" w:author="A"><w:p><w:r><w:t>Line one</w:t></w:r></w:p><w:p><w:r><w:t>Line two</w:t></w:r></w:p></w:comment></w:comments>"#;
+        let parsed = parse_comments_xml(xml);
+        // Paragraphs separated by newline (collapsed downstream).
+        assert_eq!(parsed.get("1").unwrap().body, "Line one\nLine two");
+    }
+
+    // -- unit: parse_comments_extended --
+
+    #[test]
+    fn test_parse_comments_extended_replies() {
+        let xml = r#"<?xml version="1.0"?><w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="pid_1" w15:done="0"/><w15:commentEx w15:paraId="pid_2" w15:paraIdParent="pid_1" w15:done="0"/></w15:commentsEx>"#;
+        let replies = parse_comments_extended(xml);
+        assert!(replies.contains("pid_2"));
+        assert!(!replies.contains("pid_1"));
+    }
+
+    // -- unit: collect_ranges_in_part --
+
+    #[test]
+    fn test_collect_ranges_basic_and_order() {
+        let body = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="2"/><w:r><w:t>second anchor</w:t></w:r><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="2"/></w:r></w:p><w:p><w:commentRangeStart w:id="1"/><w:r><w:t>first by id</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        );
+        let (order, text) = collect_ranges_in_part(&body);
+        // Order is by appearance: id 2 appears before id 1.
+        assert_eq!(order, vec!["2".to_string(), "1".to_string()]);
+        assert_eq!(text.get("2").map(|s| s.as_str()), Some("second anchor"));
+        assert_eq!(text.get("1").map(|s| s.as_str()), Some("first by id"));
+    }
+
+    #[test]
+    fn test_collect_ranges_zero_length_empty() {
+        let body = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        );
+        let (order, text) = collect_ranges_in_part(&body);
+        assert_eq!(order, vec!["1".to_string()]);
+        // Zero-length range -> no captured text.
+        assert!(text.get("1").map(|s| s.is_empty()).unwrap_or(true));
+    }
+
+    #[test]
+    fn test_collect_ranges_skips_mc_choice() {
+        // The range spans an mc:AlternateContent; Choice text must be excluded.
+        let body = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><mc:AlternateContent><mc:Choice Requires="wps"><w:r><w:t>CHOICE</w:t></w:r></mc:Choice><mc:Fallback><w:r><w:t>FALLBACK</w:t></w:r></mc:Fallback></mc:AlternateContent><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        );
+        let (_order, text) = collect_ranges_in_part(&body);
+        let captured = text.get("1").cloned().unwrap_or_default();
+        assert!(captured.contains("FALLBACK"), "got: {captured}");
+        assert!(!captured.contains("CHOICE"), "got: {captured}");
+    }
+
+    // -- integration --
+
+    /// A document body with one commented range on id 1.
+    fn body_with_comment_1() -> String {
+        wrap_body(
+            r#"<w:p><w:r><w:t xml:space="preserve">Intro paragraph. </w:t></w:r><w:commentRangeStart w:id="1"/><w:r><w:t>the quick brown fox</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        )
+    }
+
+    #[test]
+    fn test_docx_comments_end_to_end() {
+        let doc = body_with_comment_1();
+        let cx = comments_xml(&[(
+            "1",
+            "Jane Smith",
+            "2024-01-15T09:30:00Z",
+            "Please revise this.",
+        )]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(result.markdown.contains("## 1"));
+        assert!(
+            result
+                .markdown
+                .contains("- **author**: Jane Smith (2024-01-15T09:30:00Z)")
+        );
+        assert!(result.markdown.contains("- **comment**: Please revise this."));
+        assert!(result.markdown.contains("- **source**: the quick brown fox"));
+        // Body content is preserved above the section.
+        assert!(result.markdown.contains("Intro paragraph."));
+        let body_pos = result.markdown.find("Intro paragraph.").unwrap();
+        let cmt_pos = result.markdown.find("# Comments").unwrap();
+        assert!(body_pos < cmt_pos, "comments must be appended at the end");
+    }
+
+    #[test]
+    fn test_docx_comments_absent_when_flag_off() {
+        let doc = body_with_comment_1();
+        let cx = comments_xml(&[("1", "Jane", "2024-01-15T09:30:00Z", "Hi")]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        // Default options: extract_comments = false.
+        let result = DocxConverter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        assert!(!result.markdown.contains("# Comments"));
+        assert!(!result.plain_text.contains("Comments"));
+    }
+
+    #[test]
+    fn test_docx_comments_plain_text_stripped() {
+        let doc = body_with_comment_1();
+        let cx = comments_xml(&[("1", "Jane Smith", "2024-01-15T09:30:00Z", "Revise.")]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(result.plain_text.contains("Comments\n"));
+        assert!(result.plain_text.contains("author: Jane Smith (2024-01-15T09:30:00Z)"));
+        assert!(result.plain_text.contains("comment: Revise."));
+        assert!(result.plain_text.contains("source: the quick brown fox"));
+        // No markdown markers in the appended plain-text section.
+        assert!(!result.plain_text.contains("**"));
+        assert!(!result.plain_text.contains("# Comments"));
+    }
+
+    #[test]
+    fn test_docx_comments_unknown_author() {
+        let doc = body_with_comment_1();
+        // No author attribute on the comment.
+        let cx = r#"<?xml version="1.0"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="1"><w:p><w:r><w:t>Anonymous note</w:t></w:r></w:p></w:comment></w:comments>"#;
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(result.markdown.contains("- **author**: Unknown"), "md: {}", result.markdown);
+    }
+
+    #[test]
+    fn test_docx_comments_reply_marked() {
+        let doc = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>anchor text</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r><w:commentRangeStart w:id="2"/><w:r><w:t>more</w:t></w:r><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="2"/></w:r></w:p>"#,
+        );
+        let cx = comments_xml(&[
+            ("1", "Alice", "2024-01-01T00:00:00Z", "Top level"),
+            ("2", "Bob", "2024-01-02T00:00:00Z", "Agreed"),
+        ]);
+        // comment 2 (paraId pid_2) is a reply to comment 1 (pid_1).
+        let cex = r#"<?xml version="1.0"?><w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:commentEx w15:paraId="pid_1"/><w15:commentEx w15:paraId="pid_2" w15:paraIdParent="pid_1"/></w15:commentsEx>"#;
+        let data = build_test_docx_with_parts(
+            &doc,
+            &[
+                ("word/comments.xml", &cx),
+                ("word/commentsExtended.xml", cex),
+            ],
+        );
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(result.markdown.contains("- **comment**: Top level"));
+        assert!(
+            result.markdown.contains("- **comment**: (reply) Agreed"),
+            "reply not marked, md: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_docx_comments_source_capped_at_200() {
+        let long = "x".repeat(300);
+        let doc = wrap_body(&format!(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>{long}</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#
+        ));
+        let cx = comments_xml(&[("1", "A", "2024-01-01T00:00:00Z", "note")]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        // The source line is capped to 200 x's + ellipsis (the full 300-char run
+        // still appears in the body paragraph, so we check the source line only).
+        let expected = format!("- **source**: {}…", "x".repeat(200));
+        assert!(result.markdown.contains(&expected), "md: {}", result.markdown);
+        let source_line = result
+            .markdown
+            .lines()
+            .find(|l| l.starts_with("- **source**:"))
+            .expect("source line");
+        // 200 x's capped: line is "- **source**: " + 200 x + "…".
+        assert_eq!(source_line.matches('x').count(), 200, "line: {source_line}");
+    }
+
+    #[test]
+    fn test_docx_comments_orphan_listed_last() {
+        // Comment 1 is anchored; comment 9 has no range anywhere (orphan).
+        let doc = body_with_comment_1();
+        let cx = comments_xml(&[
+            ("1", "Anchored", "2024-01-01T00:00:00Z", "Has anchor"),
+            ("9", "Orphan", "2024-01-02T00:00:00Z", "No anchor"),
+        ]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        let anchored = result.markdown.find("Has anchor").unwrap();
+        let orphan = result.markdown.find("No anchor").unwrap();
+        assert!(anchored < orphan, "orphan must come last, md: {}", result.markdown);
+        // Orphan's source is empty.
+        assert!(result.markdown.contains("- **comment**: No anchor\n- **source**: \n"));
+    }
+
+    #[test]
+    fn test_docx_comments_header_anchor_after_body() {
+        // Comment 1 anchored in body, comment 2 anchored only in a header.
+        let doc = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>body anchor</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>"#,
+        );
+        let header = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="2"/><w:r><w:t>header anchor</w:t></w:r><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="2"/></w:r></w:p>"#,
+        );
+        let cx = comments_xml(&[
+            ("1", "BodyAuthor", "2024-01-01T00:00:00Z", "Body comment"),
+            ("2", "HeaderAuthor", "2024-01-02T00:00:00Z", "Header comment"),
+        ]);
+        let data = build_test_docx_with_parts(
+            &doc,
+            &[
+                ("word/comments.xml", &cx),
+                ("word/header1.xml", &header),
+            ],
+        );
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        let body_c = result.markdown.find("Body comment").unwrap();
+        let header_c = result.markdown.find("Header comment").unwrap();
+        assert!(body_c < header_c, "body comment must precede header comment");
+        assert!(result.markdown.contains("- **source**: header anchor"));
+    }
+
+    #[test]
+    fn test_docx_comments_unknown_range_id_warns() {
+        // Body references comment id 5, but comments.xml only has id 1.
+        let doc = wrap_body(
+            r#"<w:p><w:commentRangeStart w:id="5"/><w:r><w:t>x</w:t></w:r><w:commentRangeEnd w:id="5"/><w:r><w:commentReference w:id="5"/></w:r></w:p>"#,
+        );
+        let cx = comments_xml(&[("1", "A", "2024-01-01T00:00:00Z", "real")]);
+        let data = build_test_docx_with_parts(&doc, &[("word/comments.xml", &cx)]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == WarningCode::MalformedSegment
+                    && w.message.contains("unknown comment id")),
+            "expected malformed-segment warning, warnings: {:?}",
+            result.warnings
+        );
+        // Comment 1 is an orphan but still emitted.
+        assert!(result.markdown.contains("- **comment**: real"));
+    }
+
+    #[test]
+    fn test_docx_comments_none_present_no_section() {
+        // extract_comments on, but the document has no comments.xml.
+        let doc = wrap_body(&para("Just text."));
+        let data = build_test_docx_with_parts(&doc, &[]);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = DocxConverter.convert(&data, &options).unwrap();
+        assert!(!result.markdown.contains("# Comments"));
     }
 }

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -5,6 +5,7 @@
 //! are re-exported from the crate root.
 
 pub mod code;
+pub(crate) mod comments;
 pub mod csv;
 pub mod docx;
 pub mod gemini;
@@ -82,6 +83,9 @@ pub struct ConversionWarning {
 pub struct ConversionOptions {
     /// Extract embedded images into `ConversionResult.images`.
     pub extract_images: bool,
+    /// Extract document comments (DOCX/PPTX only) into an appended
+    /// `# Comments` section. Ignored for formats without comments.
+    pub extract_comments: bool,
     /// Hard cap for total extracted image bytes per document.
     pub max_total_image_bytes: usize,
     /// If true, return an error on recoverable parse failures instead of warnings.
@@ -98,6 +102,7 @@ impl std::fmt::Debug for ConversionOptions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ConversionOptions")
             .field("extract_images", &self.extract_images)
+            .field("extract_comments", &self.extract_comments)
             .field("max_total_image_bytes", &self.max_total_image_bytes)
             .field("strict", &self.strict)
             .field("max_input_bytes", &self.max_input_bytes)
@@ -117,6 +122,7 @@ impl Default for ConversionOptions {
     fn default() -> Self {
         Self {
             extract_images: false,
+            extract_comments: false,
             max_total_image_bytes: 4_usize.saturating_mul(1024 * 1024 * 1024), // 4 GiB (usize::MAX on 32-bit)
             strict: false,
             max_input_bytes: 8_usize.saturating_mul(1024 * 1024 * 1024), // 8 GiB (usize::MAX on 32-bit)
@@ -475,6 +481,11 @@ mod tests {
     fn test_conversion_options_default_has_no_describer() {
         let opts = ConversionOptions::default();
         assert!(opts.image_describer.is_none());
+    }
+
+    #[test]
+    fn test_conversion_options_default_extract_comments_false() {
+        assert!(!ConversionOptions::default().extract_comments);
     }
 
     #[test]

--- a/src/converter/ooxml_utils.rs
+++ b/src/converter/ooxml_utils.rs
@@ -82,6 +82,28 @@ pub(crate) fn parse_relationships(xml: &str) -> HashMap<String, Relationship> {
     rels
 }
 
+/// Read an attribute by local name from an element, XML-unescaping the value.
+///
+/// Matches on the attribute's local name (ignoring any namespace prefix) and
+/// decodes entity references (`&amp;`, `&lt;`, …), falling back to a lossy
+/// decode if unescaping fails. Returns `None` if the attribute is absent.
+pub(crate) fn attr_value_unescaped(
+    e: &quick_xml::events::BytesStart,
+    local: &str,
+) -> Option<String> {
+    for attr in e.attributes().flatten() {
+        let key = attr.key.local_name();
+        if std::str::from_utf8(key.as_ref()).unwrap_or("") == local {
+            let val = attr
+                .unescape_value()
+                .map(|v| v.into_owned())
+                .unwrap_or_else(|_| String::from_utf8_lossy(attr.value.as_ref()).to_string());
+            return Some(val);
+        }
+    }
+    None
+}
+
 /// Derive the .rels path for a given file path.
 ///
 /// Example: `ppt/slides/slide1.xml` -> `ppt/slides/_rels/slide1.xml.rels`
@@ -284,6 +306,34 @@ pub(crate) async fn resolve_image_placeholders_async(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quick_xml::events::Event;
+
+    /// Read the first start/empty element from `xml` and run `f` on it.
+    fn with_first_element<R>(xml: &str, f: impl FnOnce(&quick_xml::events::BytesStart) -> R) -> R {
+        let mut reader = Reader::from_str(xml);
+        loop {
+            match reader.read_event() {
+                Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => return f(e),
+                Ok(Event::Eof) => panic!("no element in {xml}"),
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_attr_value_unescaped_decodes_entities() {
+        with_first_element(r#"<e a="R&amp;D &lt;ok&gt;"/>"#, |e| {
+            assert_eq!(attr_value_unescaped(e, "a").as_deref(), Some("R&D <ok>"));
+        });
+    }
+
+    #[test]
+    fn test_attr_value_unescaped_ignores_prefix_and_missing() {
+        with_first_element(r#"<e w:author="Jane"/>"#, |e| {
+            assert_eq!(attr_value_unescaped(e, "author").as_deref(), Some("Jane"));
+            assert_eq!(attr_value_unescaped(e, "missing"), None);
+        });
+    }
 
     #[test]
     fn test_parse_relationships_basic() {

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -14,15 +14,15 @@ use zip::ZipArchive;
 
 use crate::converter::comments::{self, Comment};
 use crate::converter::ooxml_utils::{
-    ImageInfo, PendingImageResolution, Relationship, derive_rels_path, parse_relationships,
-    resolve_image_placeholders, resolve_relative_to_file,
+    ImageInfo, PendingImageResolution, Relationship, attr_value_unescaped, derive_rels_path,
+    parse_relationships, resolve_image_placeholders, resolve_relative_to_file,
 };
 use crate::converter::{
     ConversionOptions, ConversionResult, ConversionWarning, Converter, WarningCode,
 };
 use crate::error::ConvertError;
 use crate::markdown::{build_table, build_table_plain};
-use crate::zip_utils::{read_zip_bytes, read_zip_text};
+use crate::zip_utils::{read_zip_bytes, read_zip_text, read_zip_text_lossy};
 
 /// Converts PPTX files to Markdown.
 pub struct PptxConverter;
@@ -831,69 +831,24 @@ fn render_slide(
 
 // ---- Comment extraction ----
 
-/// Parse a legacy author registry (`ppt/commentAuthors.xml`).
+/// Parse an author registry, mapping each author `id` to its `name`.
 ///
-/// Maps the integer `id` to the author `name`. Elements:
-/// `<p:cmAuthor id="0" name="Julie Lee" initials="JL"/>`.
-fn parse_comment_authors_legacy(xml: &str) -> HashMap<String, String> {
+/// `elem` is the author element's local name — `cmAuthor` for the legacy
+/// `ppt/commentAuthors.xml` (`<p:cmAuthor id="0" name="Julie Lee"/>`) or
+/// `author` for the modern `ppt/authors.xml` (`<p188:author id="{GUID}"
+/// name="Julie Lee"/>`). Names are XML-unescaped.
+fn parse_author_registry(xml: &str, elem: &str) -> HashMap<String, String> {
     let mut reader = Reader::from_str(xml);
     let mut authors = HashMap::new();
     loop {
         match reader.read_event() {
             Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
                 let local = e.local_name();
-                if std::str::from_utf8(local.as_ref()).unwrap_or("") == "cmAuthor" {
-                    let (mut id, mut name) = (None, String::new());
-                    for attr in e.attributes().flatten() {
-                        let k = attr.key.local_name();
-                        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                        let v = String::from_utf8_lossy(&attr.value).to_string();
-                        match k {
-                            "id" => id = Some(v),
-                            "name" => name = v,
-                            _ => {}
-                        }
-                    }
-                    if let Some(id) = id {
-                        authors.insert(id, name);
-                    }
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(_) => break,
-            _ => {}
-        }
-    }
-    authors
-}
-
-/// Parse a modern author registry (`ppt/authors.xml`).
-///
-/// Maps the GUID `id` to the author `name`. Elements:
-/// `<p188:author id="{GUID}" name="Julie Lee"/>` in the
-/// `http://schemas.microsoft.com/office/powerpoint/2018/8/main` namespace.
-fn parse_authors_modern(xml: &str) -> HashMap<String, String> {
-    let mut reader = Reader::from_str(xml);
-    let mut authors = HashMap::new();
-    loop {
-        match reader.read_event() {
-            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
-                let local = e.local_name();
-                if std::str::from_utf8(local.as_ref()).unwrap_or("") == "author" {
-                    let (mut id, mut name) = (None, String::new());
-                    for attr in e.attributes().flatten() {
-                        let k = attr.key.local_name();
-                        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                        let v = String::from_utf8_lossy(&attr.value).to_string();
-                        match k {
-                            "id" => id = Some(v),
-                            "name" => name = v,
-                            _ => {}
-                        }
-                    }
-                    if let Some(id) = id {
-                        authors.insert(id, name);
-                    }
+                if std::str::from_utf8(local.as_ref()).unwrap_or("") == elem
+                    && let Some(id) = attr_value_unescaped(e, "id")
+                {
+                    let name = attr_value_unescaped(e, "name").unwrap_or_default();
+                    authors.insert(id, name);
                 }
             }
             Ok(Event::Eof) => break,
@@ -929,7 +884,10 @@ fn parse_legacy_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<Ra
 
     loop {
         match reader.read_event() {
-            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+            // Only Event::Start sets in_text: a self-closing `<p:text/>` (Empty,
+            // no End) would otherwise leave in_text stuck true and leak later
+            // text into the body.
+            Ok(Event::Start(ref e)) => {
                 let local = e.local_name();
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
                 match local_str {
@@ -938,21 +896,31 @@ fn parse_legacy_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<Ra
                         author = String::new();
                         date = String::new();
                         body = String::new();
-                        for attr in e.attributes().flatten() {
-                            let k = attr.key.local_name();
-                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                            let v = String::from_utf8_lossy(&attr.value).to_string();
-                            match k {
-                                "authorId" => {
-                                    author = authors.get(&v).cloned().unwrap_or_default();
-                                }
-                                "dt" => date = v,
-                                _ => {}
-                            }
+                        if let Some(v) = attr_value_unescaped(e, "authorId") {
+                            author = authors.get(&v).cloned().unwrap_or_default();
+                        }
+                        if let Some(v) = attr_value_unescaped(e, "dt") {
+                            date = v;
                         }
                     }
                     "text" if in_cm => in_text = true,
                     _ => {}
+                }
+            }
+            // A self-closing `<p:cm .../>` (no children) still yields a comment.
+            Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                if std::str::from_utf8(local.as_ref()).unwrap_or("") == "cm" {
+                    let author = attr_value_unescaped(e, "authorId")
+                        .and_then(|v| authors.get(&v).cloned())
+                        .unwrap_or_default();
+                    let date = attr_value_unescaped(e, "dt").unwrap_or_default();
+                    out.push(RawPptxComment {
+                        author,
+                        date,
+                        body: String::new(),
+                        is_reply: false,
+                    });
                 }
             }
             Ok(Event::Text(ref e)) if in_text => {
@@ -1015,37 +983,46 @@ fn parse_modern_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<Ra
     let mut next_seq: usize = 0;
     let mut in_text = false;
 
+    // Build a Frame from a cm/reply element's attributes.
+    let make_frame = |e: &quick_xml::events::BytesStart, is_reply: bool, seq: usize| {
+        let author = attr_value_unescaped(e, "authorId")
+            .and_then(|v| authors.get(&v).cloned())
+            .unwrap_or_default();
+        let date = attr_value_unescaped(e, "created").unwrap_or_default();
+        Frame {
+            seq,
+            author,
+            date,
+            body: String::new(),
+            is_reply,
+        }
+    };
+
     loop {
         match reader.read_event() {
-            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+            Ok(Event::Start(ref e)) => {
                 let local = e.local_name();
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
                 match local_str {
                     "cm" | "reply" => {
-                        let mut frame = Frame {
-                            seq: next_seq,
-                            author: String::new(),
-                            date: String::new(),
-                            body: String::new(),
-                            is_reply: local_str == "reply",
-                        };
+                        stack.push(make_frame(e, local_str == "reply", next_seq));
                         next_seq += 1;
-                        for attr in e.attributes().flatten() {
-                            let k = attr.key.local_name();
-                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
-                            let v = String::from_utf8_lossy(&attr.value).to_string();
-                            match k {
-                                "authorId" => {
-                                    frame.author = authors.get(&v).cloned().unwrap_or_default();
-                                }
-                                "created" => frame.date = v,
-                                _ => {}
-                            }
-                        }
-                        stack.push(frame);
                     }
+                    // Only Event::Start sets in_text: a self-closing `<a:t/>`
+                    // (Empty, no End) would otherwise leak later text into the
+                    // innermost open frame's body.
                     "t" if !stack.is_empty() => in_text = true,
                     _ => {}
+                }
+            }
+            Ok(Event::Empty(ref e)) => {
+                // A self-closing `<p188:cm/>`/`<p188:reply/>` (no body) is a
+                // complete empty comment.
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                if local_str == "cm" || local_str == "reply" {
+                    finished.push(make_frame(e, local_str == "reply", next_seq));
+                    next_seq += 1;
                 }
             }
             Ok(Event::Text(ref e)) if in_text => {
@@ -1087,11 +1064,16 @@ fn parse_modern_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<Ra
 
 /// Build the slide-label `source` for a PPTX comment: `Slide N: Title` when the
 /// slide has a title, else `Slide N`.
+///
+/// The title's internal whitespace is collapsed (a multi-paragraph or
+/// `<a:br/>`-bearing title contains newlines) and the label is capped, so the
+/// rendered `- **source**:` line never breaks across multiple lines.
 fn slide_label(number: usize, title: Option<&str>) -> String {
-    match title {
-        Some(t) if !t.trim().is_empty() => format!("Slide {number}: {}", t.trim()),
+    let label = match title.map(comments::collapse_ws) {
+        Some(t) if !t.is_empty() => format!("Slide {number}: {t}"),
         _ => format!("Slide {number}"),
-    }
+    };
+    comments::cap_text(&label, comments::SOURCE_CAP)
 }
 
 /// Convert raw PPTX comments for one slide into rendered [`Comment`]s.
@@ -1158,11 +1140,11 @@ impl PptxConverter {
         // Load comment author registries (legacy + modern) once, if requested.
         let comment_authors = if options.extract_comments {
             let mut map = HashMap::new();
-            if let Some(xml) = read_zip_text(&mut archive, "ppt/commentAuthors.xml")? {
-                map.extend(parse_comment_authors_legacy(&xml));
+            if let Some(xml) = read_zip_text_lossy(&mut archive, "ppt/commentAuthors.xml")? {
+                map.extend(parse_author_registry(&xml, "cmAuthor"));
             }
-            if let Some(xml) = read_zip_text(&mut archive, "ppt/authors.xml")? {
-                map.extend(parse_authors_modern(&xml));
+            if let Some(xml) = read_zip_text_lossy(&mut archive, "ppt/authors.xml")? {
+                map.extend(parse_author_registry(&xml, "author"));
             }
             map
         } else {
@@ -1224,19 +1206,26 @@ impl PptxConverter {
                 let source = slide_label(slide_info.number, slide_title);
                 // Collect comment-part targets, sorted by path for deterministic
                 // ordering when a slide references more than one comment file.
+                // The modern scheme uses the office/2018/10 namespace; legacy
+                // uses the 2006 one.
                 let mut comment_targets: Vec<(String, bool)> = slide_rels
                     .values()
                     .filter(|rel| rel.rel_type.contains("comments"))
                     .map(|rel| {
                         let path = resolve_relative_to_file(&slide_info.path, &rel.target);
-                        // The modern scheme uses the office/2018/10 namespace;
-                        // legacy uses the 2006 one.
                         (path, rel.rel_type.contains("2018"))
                     })
                     .collect();
                 comment_targets.sort();
+                // A slide can carry BOTH a modern and a legacy comment part for
+                // back-compat, describing the same threads. Prefer modern and
+                // skip legacy in that case to avoid double-reporting.
+                let has_modern = comment_targets.iter().any(|(_, m)| *m);
                 for (path, is_modern) in comment_targets {
-                    let Some(xml) = read_zip_text(&mut archive, &path)? else {
+                    if has_modern && !is_modern {
+                        continue;
+                    }
+                    let Some(xml) = read_zip_text_lossy(&mut archive, &path)? else {
                         continue;
                     };
                     let raw = if is_modern {
@@ -2395,7 +2384,7 @@ mod tests {
     #[test]
     fn test_parse_comment_authors_legacy() {
         let xml = r#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Julie Lee" initials="JL"/><p:cmAuthor id="1" name="Sam Park" initials="SP"/></p:cmAuthorLst>"#;
-        let authors = parse_comment_authors_legacy(xml);
+        let authors = parse_author_registry(xml, "cmAuthor");
         assert_eq!(authors.get("0").map(|s| s.as_str()), Some("Julie Lee"));
         assert_eq!(authors.get("1").map(|s| s.as_str()), Some("Sam Park"));
     }
@@ -2403,7 +2392,7 @@ mod tests {
     #[test]
     fn test_parse_authors_modern() {
         let xml = r#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{GUID-1}" name="Julie Lee" initials="JL" userId="u1" providerId="AD"/></p188:authorLst>"#;
-        let authors = parse_authors_modern(xml);
+        let authors = parse_author_registry(xml, "author");
         assert_eq!(
             authors.get("{GUID-1}").map(|s| s.as_str()),
             Some("Julie Lee")
@@ -2459,6 +2448,43 @@ mod tests {
         );
         assert_eq!(slide_label(2, None), "Slide 2");
         assert_eq!(slide_label(3, Some("   ")), "Slide 3");
+    }
+
+    #[test]
+    fn test_slide_label_collapses_newline_in_title() {
+        // Finding 2: a multi-line title must not inject a newline that breaks the
+        // single-line `- **source**:` list item.
+        let label = slide_label(1, Some("Line1\nLine2"));
+        assert!(!label.contains('\n'), "label has a newline: {label:?}");
+        assert_eq!(label, "Slide 1: Line1 Line2");
+    }
+
+    #[test]
+    fn test_parse_legacy_comments_self_closing_text_no_leak() {
+        // Finding 5: self-closing <p:text/> must not capture stray sibling text.
+        let xml = r#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="0" dt="d"><p:text/></p:cm></p:cmLst>"#;
+        let authors = HashMap::new();
+        let raw = parse_legacy_comments(xml, &authors);
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].body, "");
+    }
+
+    #[test]
+    fn test_parse_modern_comments_self_closing_text_no_leak() {
+        // Finding 5: self-closing <a:t/> must not leak text into the body.
+        let xml = r#"<?xml version="1.0"?><p188:cmLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p188:cm authorId="a" created="c"><p188:txBody><a:p><a:r><a:t/></a:r><a:r><a:t>real</a:t></a:r></a:p></p188:txBody></p188:cm></p188:cmLst>"#;
+        let authors = HashMap::new();
+        let raw = parse_modern_comments(xml, &authors);
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].body, "real");
+    }
+
+    #[test]
+    fn test_parse_author_registry_unescapes_name() {
+        // Finding 8: author names must be XML-unescaped.
+        let xml = r#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Ben &amp; Jerry"/></p:cmAuthorLst>"#;
+        let authors = parse_author_registry(xml, "cmAuthor");
+        assert_eq!(authors.get("0").map(|s| s.as_str()), Some("Ben & Jerry"));
     }
 
     // -- integration: build a PPTX with comment parts --
@@ -2620,5 +2646,60 @@ mod tests {
         assert!(result.plain_text.contains("source: Slide 1: Overview"));
         assert!(!result.plain_text.contains("# Comments"));
         assert!(!result.plain_text.contains("**"));
+    }
+
+    #[test]
+    fn test_pptx_dual_scheme_no_double_report() {
+        // Finding 2: a slide referencing BOTH a legacy and a modern comment part
+        // (same thread, for back-compat) must not report the comment twice.
+        use std::io::Write;
+        use zip::ZipWriter;
+        use zip::write::SimpleFileOptions;
+
+        let buf = Vec::new();
+        let mut zip = ZipWriter::new(Cursor::new(buf));
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#).unwrap();
+        zip.start_file("ppt/presentation.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>"#).unwrap();
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts)
+            .unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#).unwrap();
+        zip.start_file("ppt/slides/slide1.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree/></p:cSld></p:sld>"#).unwrap();
+        // Slide rels carry BOTH a legacy and a modern comments relationship.
+        zip.start_file("ppt/slides/_rels/slide1.xml.rels", opts)
+            .unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdL" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments/comment1.xml"/><Relationship Id="rIdM" Type="http://schemas.microsoft.com/office/2018/10/relationships/comments" Target="../comments/modernComment_x.xml"/></Relationships>"#).unwrap();
+        zip.start_file("ppt/commentAuthors.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Dana"/></p:cmAuthorLst>"#).unwrap();
+        zip.start_file("ppt/comments/comment1.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="0" dt="d" idx="1"><p:text>Shared thread.</p:text></p:cm></p:cmLst>"#).unwrap();
+        zip.start_file("ppt/authors.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{A}" name="Dana" userId="u" providerId="AD"/></p188:authorLst>"#).unwrap();
+        zip.start_file("ppt/comments/modernComment_x.xml", opts)
+            .unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p188:cmLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p188:cm authorId="{A}" created="c"><p188:txBody><a:p><a:r><a:t>Shared thread.</a:t></a:r></a:p></p188:txBody></p188:cm></p188:cmLst>"#).unwrap();
+
+        let data = zip.finish().unwrap().into_inner();
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = PptxConverter.convert(&data, &options).unwrap();
+        // Exactly one comment, not two.
+        assert_eq!(
+            result
+                .markdown
+                .matches("- **comment**: Shared thread.")
+                .count(),
+            1,
+            "comment double-reported, md: {}",
+            result.markdown
+        );
+        assert!(result.markdown.contains("## 1"));
+        assert!(!result.markdown.contains("## 2"));
     }
 }

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -2404,7 +2404,10 @@ mod tests {
     fn test_parse_authors_modern() {
         let xml = r#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{GUID-1}" name="Julie Lee" initials="JL" userId="u1" providerId="AD"/></p188:authorLst>"#;
         let authors = parse_authors_modern(xml);
-        assert_eq!(authors.get("{GUID-1}").map(|s| s.as_str()), Some("Julie Lee"));
+        assert_eq!(
+            authors.get("{GUID-1}").map(|s| s.as_str()),
+            Some("Julie Lee")
+        );
     }
 
     // -- unit: comment files --
@@ -2450,7 +2453,10 @@ mod tests {
 
     #[test]
     fn test_slide_label() {
-        assert_eq!(slide_label(2, Some("Quarterly Results")), "Slide 2: Quarterly Results");
+        assert_eq!(
+            slide_label(2, Some("Quarterly Results")),
+            "Slide 2: Quarterly Results"
+        );
         assert_eq!(slide_label(2, None), "Slide 2");
         assert_eq!(slide_label(3, Some("   ")), "Slide 3");
     }
@@ -2474,7 +2480,8 @@ mod tests {
         // presentation.xml + rels
         zip.start_file("ppt/presentation.xml", opts).unwrap();
         zip.write_all(br#"<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>"#).unwrap();
-        zip.start_file("ppt/_rels/presentation.xml.rels", opts).unwrap();
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts)
+            .unwrap();
         zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#).unwrap();
 
         // slide1.xml
@@ -2502,7 +2509,8 @@ mod tests {
                 "../comments/comment1.xml",
             )
         };
-        zip.start_file("ppt/slides/_rels/slide1.xml.rels", opts).unwrap();
+        zip.start_file("ppt/slides/_rels/slide1.xml.rels", opts)
+            .unwrap();
         zip.write_all(
             format!(
                 r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdC" Type="{rel_type}" Target="{comment_path}"/></Relationships>"#
@@ -2514,7 +2522,8 @@ mod tests {
         if modern {
             zip.start_file("ppt/authors.xml", opts).unwrap();
             zip.write_all(br#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{A1}" name="Alice" userId="u" providerId="AD"/><p188:author id="{A2}" name="Bob" userId="u" providerId="AD"/></p188:authorLst>"#).unwrap();
-            zip.start_file("ppt/comments/modernComment_x.xml", opts).unwrap();
+            zip.start_file("ppt/comments/modernComment_x.xml", opts)
+                .unwrap();
             zip.write_all(br#"<?xml version="1.0"?><p188:cmLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p188:cm id="{C1}" authorId="{A1}" created="2024-01-15T10:30:00.000"><p188:replyLst><p188:reply id="{C2}" authorId="{A2}" created="2024-01-15T11:00:00.000"><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Agreed.</a:t></a:r></a:p></p188:txBody></p188:reply></p188:replyLst><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Please clarify.</a:t></a:r></a:p></p188:txBody></p188:cm></p188:cmLst>"#).unwrap();
         } else {
             zip.start_file("ppt/commentAuthors.xml", opts).unwrap();
@@ -2535,14 +2544,22 @@ mod tests {
             ..Default::default()
         };
         let result = PptxConverter.convert(&data, &options).unwrap();
-        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains("# Comments"),
+            "md: {}",
+            result.markdown
+        );
         assert!(result.markdown.contains("## 1"));
         assert!(
             result
                 .markdown
                 .contains("- **author**: Julie Lee (2024-01-15T10:30:00.000)")
         );
-        assert!(result.markdown.contains("- **comment**: Add a diagram here."));
+        assert!(
+            result
+                .markdown
+                .contains("- **comment**: Add a diagram here.")
+        );
         assert!(result.markdown.contains("- **source**: Slide 1: Overview"));
     }
 
@@ -2554,7 +2571,11 @@ mod tests {
             ..Default::default()
         };
         let result = PptxConverter.convert(&data, &options).unwrap();
-        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains("# Comments"),
+            "md: {}",
+            result.markdown
+        );
         assert!(result.markdown.contains("- **comment**: Please clarify."));
         assert!(
             result.markdown.contains("- **comment**: (reply) Agreed."),
@@ -2564,7 +2585,11 @@ mod tests {
         // Parent comment must be emitted before its reply (document order).
         let parent = result.markdown.find("Please clarify.").unwrap();
         let reply = result.markdown.find("(reply) Agreed.").unwrap();
-        assert!(parent < reply, "parent must precede reply, md: {}", result.markdown);
+        assert!(
+            parent < reply,
+            "parent must precede reply, md: {}",
+            result.markdown
+        );
         // No slide title -> bare "Slide 1".
         assert!(result.markdown.contains("- **source**: Slide 1\n"));
     }
@@ -2587,7 +2612,11 @@ mod tests {
         };
         let result = PptxConverter.convert(&data, &options).unwrap();
         assert!(result.plain_text.contains("Comments\n"));
-        assert!(result.plain_text.contains("author: Julie Lee (2024-01-15T10:30:00.000)"));
+        assert!(
+            result
+                .plain_text
+                .contains("author: Julie Lee (2024-01-15T10:30:00.000)")
+        );
         assert!(result.plain_text.contains("source: Slide 1: Overview"));
         assert!(!result.plain_text.contains("# Comments"));
         assert!(!result.plain_text.contains("**"));

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -12,6 +12,7 @@ use quick_xml::Reader;
 use quick_xml::events::Event;
 use zip::ZipArchive;
 
+use crate::converter::comments::{self, Comment};
 use crate::converter::ooxml_utils::{
     ImageInfo, PendingImageResolution, Relationship, derive_rels_path, parse_relationships,
     resolve_image_placeholders, resolve_relative_to_file,
@@ -828,18 +829,297 @@ fn render_slide(
 
 // ---- Converter trait impl ----
 
+// ---- Comment extraction ----
+
+/// Parse a legacy author registry (`ppt/commentAuthors.xml`).
+///
+/// Maps the integer `id` to the author `name`. Elements:
+/// `<p:cmAuthor id="0" name="Julie Lee" initials="JL"/>`.
+fn parse_comment_authors_legacy(xml: &str) -> HashMap<String, String> {
+    let mut reader = Reader::from_str(xml);
+    let mut authors = HashMap::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                if std::str::from_utf8(local.as_ref()).unwrap_or("") == "cmAuthor" {
+                    let (mut id, mut name) = (None, String::new());
+                    for attr in e.attributes().flatten() {
+                        let k = attr.key.local_name();
+                        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                        let v = String::from_utf8_lossy(&attr.value).to_string();
+                        match k {
+                            "id" => id = Some(v),
+                            "name" => name = v,
+                            _ => {}
+                        }
+                    }
+                    if let Some(id) = id {
+                        authors.insert(id, name);
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    authors
+}
+
+/// Parse a modern author registry (`ppt/authors.xml`).
+///
+/// Maps the GUID `id` to the author `name`. Elements:
+/// `<p188:author id="{GUID}" name="Julie Lee"/>` in the
+/// `http://schemas.microsoft.com/office/powerpoint/2018/8/main` namespace.
+fn parse_authors_modern(xml: &str) -> HashMap<String, String> {
+    let mut reader = Reader::from_str(xml);
+    let mut authors = HashMap::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                if std::str::from_utf8(local.as_ref()).unwrap_or("") == "author" {
+                    let (mut id, mut name) = (None, String::new());
+                    for attr in e.attributes().flatten() {
+                        let k = attr.key.local_name();
+                        let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                        let v = String::from_utf8_lossy(&attr.value).to_string();
+                        match k {
+                            "id" => id = Some(v),
+                            "name" => name = v,
+                            _ => {}
+                        }
+                    }
+                    if let Some(id) = id {
+                        authors.insert(id, name);
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    authors
+}
+
+/// A raw PPTX comment before it is turned into a rendered [`Comment`].
+#[derive(Debug, Clone)]
+struct RawPptxComment {
+    author: String,
+    date: String,
+    body: String,
+    is_reply: bool,
+}
+
+/// Parse a legacy comment file (`ppt/comments/commentN.xml`).
+///
+/// Comments are `<p:cm authorId="0" dt="..." idx="1">` with the body as plain
+/// text in a `<p:text>` child. Legacy comments are never replies.
+fn parse_legacy_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<RawPptxComment> {
+    let mut reader = Reader::from_str(xml);
+    let mut out = Vec::new();
+
+    let mut author = String::new();
+    let mut date = String::new();
+    let mut body = String::new();
+    let mut in_cm = false;
+    let mut in_text = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "cm" => {
+                        in_cm = true;
+                        author = String::new();
+                        date = String::new();
+                        body = String::new();
+                        for attr in e.attributes().flatten() {
+                            let k = attr.key.local_name();
+                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                            let v = String::from_utf8_lossy(&attr.value).to_string();
+                            match k {
+                                "authorId" => {
+                                    author = authors.get(&v).cloned().unwrap_or_default();
+                                }
+                                "dt" => date = v,
+                                _ => {}
+                            }
+                        }
+                    }
+                    "text" if in_cm => in_text = true,
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(ref e)) if in_text => {
+                body.push_str(&e.unescape().unwrap_or_default());
+            }
+            Ok(Event::End(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "text" => in_text = false,
+                    "cm" if in_cm => {
+                        out.push(RawPptxComment {
+                            author: std::mem::take(&mut author),
+                            date: std::mem::take(&mut date),
+                            body: std::mem::take(&mut body),
+                            is_reply: false,
+                        });
+                        in_cm = false;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    out
+}
+
+/// Parse a modern comment file (`ppt/comments/modernComment_*.xml`).
+///
+/// Comments are `<p188:cm authorId="{GUID}" created="...">` whose body lives in
+/// DrawingML `<a:t>` runs inside `<p188:txBody>`. Replies are nested inside a
+/// `<p188:replyLst>` and are marked `is_reply = true`. Top-level comments and
+/// replies are emitted in document order (a parent precedes its replies).
+fn parse_modern_comments(xml: &str, authors: &HashMap<String, String>) -> Vec<RawPptxComment> {
+    let mut reader = Reader::from_str(xml);
+    let mut out = Vec::new();
+
+    /// One in-progress comment on the parse stack.
+    struct Frame {
+        /// Document start order, so a parent (whose start tag precedes its
+        /// reply's) is emitted before its replies even though it closes later.
+        seq: usize,
+        author: String,
+        date: String,
+        body: String,
+        is_reply: bool,
+    }
+
+    // Comments nest: a `cm`'s `replyLst` (and its `reply` children) appears
+    // before the `cm`'s own `txBody`. A stack keeps each comment's captured
+    // attributes and body separate; text appends to the innermost open frame.
+    // Finished frames are collected with their start `seq`, then sorted so the
+    // emit order is document order (parent before reply).
+    let mut stack: Vec<Frame> = Vec::new();
+    let mut finished: Vec<Frame> = Vec::new();
+    let mut next_seq: usize = 0;
+    let mut in_text = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "cm" | "reply" => {
+                        let mut frame = Frame {
+                            seq: next_seq,
+                            author: String::new(),
+                            date: String::new(),
+                            body: String::new(),
+                            is_reply: local_str == "reply",
+                        };
+                        next_seq += 1;
+                        for attr in e.attributes().flatten() {
+                            let k = attr.key.local_name();
+                            let k = std::str::from_utf8(k.as_ref()).unwrap_or("");
+                            let v = String::from_utf8_lossy(&attr.value).to_string();
+                            match k {
+                                "authorId" => {
+                                    frame.author = authors.get(&v).cloned().unwrap_or_default();
+                                }
+                                "created" => frame.date = v,
+                                _ => {}
+                            }
+                        }
+                        stack.push(frame);
+                    }
+                    "t" if !stack.is_empty() => in_text = true,
+                    _ => {}
+                }
+            }
+            Ok(Event::Text(ref e)) if in_text => {
+                if let Some(frame) = stack.last_mut() {
+                    frame.body.push_str(&e.unescape().unwrap_or_default());
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let local = e.local_name();
+                let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                match local_str {
+                    "t" => in_text = false,
+                    "cm" | "reply" => {
+                        if let Some(frame) = stack.pop() {
+                            finished.push(frame);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    finished.sort_by_key(|f| f.seq);
+    for frame in finished {
+        out.push(RawPptxComment {
+            author: frame.author,
+            date: frame.date,
+            body: frame.body,
+            is_reply: frame.is_reply,
+        });
+    }
+
+    out
+}
+
+/// Build the slide-label `source` for a PPTX comment: `Slide N: Title` when the
+/// slide has a title, else `Slide N`.
+fn slide_label(number: usize, title: Option<&str>) -> String {
+    match title {
+        Some(t) if !t.trim().is_empty() => format!("Slide {number}: {}", t.trim()),
+        _ => format!("Slide {number}"),
+    }
+}
+
+/// Convert raw PPTX comments for one slide into rendered [`Comment`]s.
+fn build_pptx_comments(raw: Vec<RawPptxComment>, source: &str) -> Vec<Comment> {
+    raw.into_iter()
+        .map(|rc| Comment {
+            author: comments::format_author(&rc.author, &rc.date),
+            body: comments::collapse_ws(&rc.body),
+            source: source.to_string(),
+            is_reply: rc.is_reply,
+        })
+        .collect()
+}
+
 // ---- Internal conversion (parse + image extraction, no resolution) ----
 
 impl PptxConverter {
     /// Parse the presentation and extract images without resolving placeholders.
     ///
-    /// Returns the conversion result (with unresolved placeholders in markdown)
-    /// and pending image data for later resolution (sync or async).
+    /// Returns the conversion result (with unresolved placeholders in markdown),
+    /// pending image data for later resolution (sync or async), and any extracted
+    /// comments (empty unless `options.extract_comments` is set). Comments are
+    /// appended to the output by the caller, after image placeholders resolve.
     pub(crate) fn convert_inner(
         &self,
         data: &[u8],
         options: &ConversionOptions,
-    ) -> Result<(ConversionResult, PendingImageResolution), ConvertError> {
+    ) -> Result<(ConversionResult, PendingImageResolution, Vec<Comment>), ConvertError> {
         let cursor = Cursor::new(data);
         let mut archive = ZipArchive::new(cursor)?;
 
@@ -871,8 +1151,23 @@ impl PptxConverter {
                     ..Default::default()
                 },
                 PendingImageResolution::default(),
+                Vec::new(),
             ));
         }
+
+        // Load comment author registries (legacy + modern) once, if requested.
+        let comment_authors = if options.extract_comments {
+            let mut map = HashMap::new();
+            if let Some(xml) = read_zip_text(&mut archive, "ppt/commentAuthors.xml")? {
+                map.extend(parse_comment_authors_legacy(&xml));
+            }
+            if let Some(xml) = read_zip_text(&mut archive, "ppt/authors.xml")? {
+                map.extend(parse_authors_modern(&xml));
+            }
+            map
+        } else {
+            HashMap::new()
+        };
 
         // 4. Process each slide — collect all image infos and bytes across slides
         let mut slide_markdowns: Vec<String> = Vec::new();
@@ -882,6 +1177,7 @@ impl PptxConverter {
         let mut image_counter: usize = 0;
         let mut all_image_infos: Vec<ImageInfo> = Vec::new();
         let mut all_image_bytes: HashMap<String, Vec<u8>> = HashMap::new();
+        let mut all_comments: Vec<Comment> = Vec::new();
 
         for slide_info in &slides {
             // Read slide XML
@@ -918,6 +1214,39 @@ impl PptxConverter {
             } else {
                 None
             };
+
+            // Extract comments anchored to this slide (legacy + modern schemes).
+            if options.extract_comments {
+                let slide_title = shapes.iter().find_map(|s| match s {
+                    ShapeContent::Title(t) => Some(t.as_str()),
+                    _ => None,
+                });
+                let source = slide_label(slide_info.number, slide_title);
+                // Collect comment-part targets, sorted by path for deterministic
+                // ordering when a slide references more than one comment file.
+                let mut comment_targets: Vec<(String, bool)> = slide_rels
+                    .values()
+                    .filter(|rel| rel.rel_type.contains("comments"))
+                    .map(|rel| {
+                        let path = resolve_relative_to_file(&slide_info.path, &rel.target);
+                        // The modern scheme uses the office/2018/10 namespace;
+                        // legacy uses the 2006 one.
+                        (path, rel.rel_type.contains("2018"))
+                    })
+                    .collect();
+                comment_targets.sort();
+                for (path, is_modern) in comment_targets {
+                    let Some(xml) = read_zip_text(&mut archive, &path)? else {
+                        continue;
+                    };
+                    let raw = if is_modern {
+                        parse_modern_comments(&xml, &comment_authors)
+                    } else {
+                        parse_legacy_comments(&xml, &comment_authors)
+                    };
+                    all_comments.extend(build_pptx_comments(raw, &source));
+                }
+            }
 
             // Resolve image filenames and optionally extract image data
             let need_image_bytes = options.extract_images || options.image_describer.is_some();
@@ -1008,7 +1337,7 @@ impl PptxConverter {
             bytes: all_image_bytes,
         };
 
-        Ok((result, pending))
+        Ok((result, pending, all_comments))
     }
 }
 
@@ -1024,7 +1353,7 @@ impl Converter for PptxConverter {
         data: &[u8],
         options: &ConversionOptions,
     ) -> Result<ConversionResult, ConvertError> {
-        let (mut result, pending) = self.convert_inner(data, options)?;
+        let (mut result, pending, doc_comments) = self.convert_inner(data, options)?;
         resolve_image_placeholders(
             &mut result.markdown,
             &mut result.plain_text,
@@ -1033,6 +1362,7 @@ impl Converter for PptxConverter {
             options.image_describer.as_deref(),
             &mut result.warnings,
         );
+        comments::append_comments(&mut result.markdown, &mut result.plain_text, &doc_comments);
         Ok(result)
     }
 }
@@ -2056,5 +2386,210 @@ mod tests {
         let (shapes, warnings) = parse_slide(slide_xml);
         assert!(warnings.is_empty());
         assert!(shapes.is_empty());
+    }
+
+    // ---- Comment extraction tests ----
+
+    // -- unit: author registries --
+
+    #[test]
+    fn test_parse_comment_authors_legacy() {
+        let xml = r#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Julie Lee" initials="JL"/><p:cmAuthor id="1" name="Sam Park" initials="SP"/></p:cmAuthorLst>"#;
+        let authors = parse_comment_authors_legacy(xml);
+        assert_eq!(authors.get("0").map(|s| s.as_str()), Some("Julie Lee"));
+        assert_eq!(authors.get("1").map(|s| s.as_str()), Some("Sam Park"));
+    }
+
+    #[test]
+    fn test_parse_authors_modern() {
+        let xml = r#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{GUID-1}" name="Julie Lee" initials="JL" userId="u1" providerId="AD"/></p188:authorLst>"#;
+        let authors = parse_authors_modern(xml);
+        assert_eq!(authors.get("{GUID-1}").map(|s| s.as_str()), Some("Julie Lee"));
+    }
+
+    // -- unit: comment files --
+
+    #[test]
+    fn test_parse_legacy_comments() {
+        let mut authors = HashMap::new();
+        authors.insert("0".to_string(), "Julie Lee".to_string());
+        let xml = r#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="0" dt="2024-01-15T10:30:00.000" idx="1"><p:pos x="10" y="10"/><p:text>Add a diagram here.</p:text></p:cm></p:cmLst>"#;
+        let raw = parse_legacy_comments(xml, &authors);
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].author, "Julie Lee");
+        assert_eq!(raw[0].date, "2024-01-15T10:30:00.000");
+        assert_eq!(raw[0].body, "Add a diagram here.");
+        assert!(!raw[0].is_reply);
+    }
+
+    #[test]
+    fn test_parse_legacy_comments_unknown_author_empty() {
+        let authors = HashMap::new();
+        let xml = r#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="7" dt="2024-01-15T10:30:00.000" idx="1"><p:text>Orphan author.</p:text></p:cm></p:cmLst>"#;
+        let raw = parse_legacy_comments(xml, &authors);
+        assert_eq!(raw[0].author, ""); // resolved to Unknown downstream
+        assert_eq!(raw[0].body, "Orphan author.");
+    }
+
+    #[test]
+    fn test_parse_modern_comments_with_reply() {
+        let mut authors = HashMap::new();
+        authors.insert("{A1}".to_string(), "Alice".to_string());
+        authors.insert("{A2}".to_string(), "Bob".to_string());
+        let xml = r#"<?xml version="1.0"?><p188:cmLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p188:cm id="{C1}" authorId="{A1}" created="2024-01-15T10:30:00.000" status="active"><p188:replyLst><p188:reply id="{C2}" authorId="{A2}" created="2024-01-15T11:00:00.000" status="active"><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Agreed, will fix.</a:t></a:r></a:p></p188:txBody></p188:reply></p188:replyLst><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Needs a clearer title.</a:t></a:r></a:p></p188:txBody></p188:cm></p188:cmLst>"#;
+        let raw = parse_modern_comments(xml, &authors);
+        assert_eq!(raw.len(), 2);
+        // The reply closes first (nested), then the parent.
+        let reply = raw.iter().find(|c| c.is_reply).expect("a reply");
+        let top = raw.iter().find(|c| !c.is_reply).expect("a top-level");
+        assert_eq!(reply.author, "Bob");
+        assert_eq!(reply.body, "Agreed, will fix.");
+        assert_eq!(top.author, "Alice");
+        assert_eq!(top.body, "Needs a clearer title.");
+    }
+
+    #[test]
+    fn test_slide_label() {
+        assert_eq!(slide_label(2, Some("Quarterly Results")), "Slide 2: Quarterly Results");
+        assert_eq!(slide_label(2, None), "Slide 2");
+        assert_eq!(slide_label(3, Some("   ")), "Slide 3");
+    }
+
+    // -- integration: build a PPTX with comment parts --
+
+    /// Build a one-slide PPTX with a single legacy or modern comment part.
+    /// `modern` selects the relationship type + comment-file XML scheme.
+    fn build_pptx_with_comment(modern: bool, slide_title: Option<&str>) -> Vec<u8> {
+        use std::io::Write;
+        use zip::ZipWriter;
+        use zip::write::SimpleFileOptions;
+
+        let buf = Vec::new();
+        let mut zip = ZipWriter::new(Cursor::new(buf));
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#).unwrap();
+
+        // presentation.xml + rels
+        zip.start_file("ppt/presentation.xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>"#).unwrap();
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#).unwrap();
+
+        // slide1.xml
+        let title_shape = match slide_title {
+            Some(t) => format!(
+                r#"<p:sp><p:nvSpPr><p:cNvPr id="1" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:txBody><a:p><a:r><a:t>{t}</a:t></a:r></a:p></p:txBody></p:sp>"#
+            ),
+            None => String::new(),
+        };
+        let slide = format!(
+            r#"<?xml version="1.0"?><p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree>{title_shape}</p:spTree></p:cSld></p:sld>"#
+        );
+        zip.start_file("ppt/slides/slide1.xml", opts).unwrap();
+        zip.write_all(slide.as_bytes()).unwrap();
+
+        // slide rels -> comment part
+        let (rel_type, comment_path) = if modern {
+            (
+                "http://schemas.microsoft.com/office/2018/10/relationships/comments",
+                "../comments/modernComment_x.xml",
+            )
+        } else {
+            (
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments",
+                "../comments/comment1.xml",
+            )
+        };
+        zip.start_file("ppt/slides/_rels/slide1.xml.rels", opts).unwrap();
+        zip.write_all(
+            format!(
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdC" Type="{rel_type}" Target="{comment_path}"/></Relationships>"#
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+        if modern {
+            zip.start_file("ppt/authors.xml", opts).unwrap();
+            zip.write_all(br#"<?xml version="1.0"?><p188:authorLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main"><p188:author id="{A1}" name="Alice" userId="u" providerId="AD"/><p188:author id="{A2}" name="Bob" userId="u" providerId="AD"/></p188:authorLst>"#).unwrap();
+            zip.start_file("ppt/comments/modernComment_x.xml", opts).unwrap();
+            zip.write_all(br#"<?xml version="1.0"?><p188:cmLst xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p188:cm id="{C1}" authorId="{A1}" created="2024-01-15T10:30:00.000"><p188:replyLst><p188:reply id="{C2}" authorId="{A2}" created="2024-01-15T11:00:00.000"><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Agreed.</a:t></a:r></a:p></p188:txBody></p188:reply></p188:replyLst><p188:txBody><a:bodyPr/><a:p><a:r><a:t>Please clarify.</a:t></a:r></a:p></p188:txBody></p188:cm></p188:cmLst>"#).unwrap();
+        } else {
+            zip.start_file("ppt/commentAuthors.xml", opts).unwrap();
+            zip.write_all(br#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Julie Lee" initials="JL"/></p:cmAuthorLst>"#).unwrap();
+            zip.start_file("ppt/comments/comment1.xml", opts).unwrap();
+            zip.write_all(br#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="0" dt="2024-01-15T10:30:00.000" idx="1"><p:pos x="10" y="10"/><p:text>Add a diagram here.</p:text></p:cm></p:cmLst>"#).unwrap();
+        }
+
+        let cursor = zip.finish().unwrap();
+        cursor.into_inner()
+    }
+
+    #[test]
+    fn test_pptx_legacy_comments_end_to_end() {
+        let data = build_pptx_with_comment(false, Some("Overview"));
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = PptxConverter.convert(&data, &options).unwrap();
+        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(result.markdown.contains("## 1"));
+        assert!(
+            result
+                .markdown
+                .contains("- **author**: Julie Lee (2024-01-15T10:30:00.000)")
+        );
+        assert!(result.markdown.contains("- **comment**: Add a diagram here."));
+        assert!(result.markdown.contains("- **source**: Slide 1: Overview"));
+    }
+
+    #[test]
+    fn test_pptx_modern_comments_with_reply_end_to_end() {
+        let data = build_pptx_with_comment(true, None);
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = PptxConverter.convert(&data, &options).unwrap();
+        assert!(result.markdown.contains("# Comments"), "md: {}", result.markdown);
+        assert!(result.markdown.contains("- **comment**: Please clarify."));
+        assert!(
+            result.markdown.contains("- **comment**: (reply) Agreed."),
+            "reply not marked, md: {}",
+            result.markdown
+        );
+        // Parent comment must be emitted before its reply (document order).
+        let parent = result.markdown.find("Please clarify.").unwrap();
+        let reply = result.markdown.find("(reply) Agreed.").unwrap();
+        assert!(parent < reply, "parent must precede reply, md: {}", result.markdown);
+        // No slide title -> bare "Slide 1".
+        assert!(result.markdown.contains("- **source**: Slide 1\n"));
+    }
+
+    #[test]
+    fn test_pptx_comments_absent_when_flag_off() {
+        let data = build_pptx_with_comment(false, Some("Overview"));
+        let result = PptxConverter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        assert!(!result.markdown.contains("# Comments"));
+    }
+
+    #[test]
+    fn test_pptx_comments_plain_text_stripped() {
+        let data = build_pptx_with_comment(false, Some("Overview"));
+        let options = ConversionOptions {
+            extract_comments: true,
+            ..Default::default()
+        };
+        let result = PptxConverter.convert(&data, &options).unwrap();
+        assert!(result.plain_text.contains("Comments\n"));
+        assert!(result.plain_text.contains("author: Julie Lee (2024-01-15T10:30:00.000)"));
+        assert!(result.plain_text.contains("source: Slide 1: Overview"));
+        assert!(!result.plain_text.contains("# Comments"));
+        assert!(!result.plain_text.contains("**"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,8 @@ pub async fn convert_bytes_async(
             }
             "pptx" => {
                 let conv = converter::pptx::PptxConverter;
-                let (mut result, pending) = conv.convert_inner(data, &options.base)?;
+                let (mut result, pending, doc_comments) =
+                    conv.convert_inner(data, &options.base)?;
                 if !pending.infos.is_empty() {
                     converter::ooxml_utils::resolve_image_placeholders_async(
                         &mut result.markdown,
@@ -360,6 +361,11 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
+                converter::comments::append_comments(
+                    &mut result.markdown,
+                    &mut result.plain_text,
+                    &doc_comments,
+                );
                 return enforce_strict_mode(result, options.base.strict);
             }
             "xlsx" | "xls" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,8 @@ pub async fn convert_bytes_async(
         match extension_norm.as_str() {
             "docx" => {
                 let conv = converter::docx::DocxConverter;
-                let (mut result, pending) = conv.convert_inner(data, &options.base)?;
+                let (mut result, pending, doc_comments) =
+                    conv.convert_inner(data, &options.base)?;
                 if !pending.infos.is_empty() {
                     converter::ooxml_utils::resolve_image_placeholders_async(
                         &mut result.markdown,
@@ -338,6 +339,11 @@ pub async fn convert_bytes_async(
                     )
                     .await;
                 }
+                converter::comments::append_comments(
+                    &mut result.markdown,
+                    &mut result.plain_text,
+                    &doc_comments,
+                );
                 return enforce_strict_mode(result, options.base.strict);
             }
             "pptx" => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -84,6 +84,10 @@ struct Cli {
     #[arg(long)]
     plain_text: bool,
 
+    /// Extract comments (DOCX/PPTX only) into an appended Comments section.
+    #[arg(long)]
+    extract_comments: bool,
+
     /// Maximum input file size (e.g., "500MB", "2GiB"). [default: 8GiB]
     #[arg(long, value_name = "SIZE", value_parser = crate::parse::byte_size)]
     max_input_size: Option<usize>,
@@ -118,6 +122,7 @@ fn build_options(cli: &Cli) -> Result<ConversionOptions, ExitCode> {
     let d = ConversionOptions::default();
     let mut options = ConversionOptions {
         strict: cli.strict,
+        extract_comments: cli.extract_comments,
         max_input_bytes: cli.max_input_size.unwrap_or(d.max_input_bytes),
         max_total_image_bytes: cli.max_image_size.unwrap_or(d.max_total_image_bytes),
         max_uncompressed_zip_bytes: cli.max_zip_size.unwrap_or(d.max_uncompressed_zip_bytes),

--- a/src/zip_utils.rs
+++ b/src/zip_utils.rs
@@ -42,6 +42,25 @@ pub(crate) fn read_zip_text(
     Ok(Some(buf))
 }
 
+/// Read a text file from a ZIP archive with a lossy UTF-8 decode.
+///
+/// Unlike [`read_zip_text`], invalid UTF-8 bytes are replaced with U+FFFD rather
+/// than returning an error. Used for best-effort, opt-in parts (e.g. comments)
+/// where a single malformed sub-part must not abort the whole conversion.
+pub(crate) fn read_zip_text_lossy(
+    archive: &mut ZipArchive<Cursor<&[u8]>>,
+    path: &str,
+) -> Result<Option<String>, ConvertError> {
+    let mut file = match archive.by_name(path) {
+        Ok(f) => f,
+        Err(zip::result::ZipError::FileNotFound) => return Ok(None),
+        Err(e) => return Err(ConvertError::ZipError(e)),
+    };
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    Ok(Some(String::from_utf8_lossy(&buf).into_owned()))
+}
+
 /// Read raw bytes from a ZIP archive, returning None if not found.
 pub(crate) fn read_zip_bytes(
     archive: &mut ZipArchive<Cursor<&[u8]>>,

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -306,3 +306,37 @@ fn test_cli_plain_text_with_size_limits() {
         .success()
         .stdout(predicate::str::contains("Alice"));
 }
+
+/// --extract-comments is listed in --help.
+#[test]
+fn test_cli_extract_comments_in_help() {
+    cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--extract-comments"));
+}
+
+/// --extract-comments is a harmless no-op for formats without comments (CSV).
+#[test]
+fn test_cli_extract_comments_noop_on_csv() {
+    cmd()
+        .args(["--extract-comments", "tests/fixtures/sample.csv"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Alice"))
+        .stdout(predicate::str::contains("# Comments").not());
+}
+
+/// --extract-comments extracts the Comments section from the sample DOCX
+/// (only if that fixture actually contains comments — otherwise no section).
+#[test]
+fn test_cli_extract_comments_docx_runs() {
+    // The flag must not break DOCX conversion regardless of whether the fixture
+    // has comments; the body content must still be present.
+    cmd()
+        .args(["--extract-comments", "tests/fixtures/sample.docx"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Sample Document"));
+}

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -267,3 +267,94 @@ fn test_docx_textbox_convert_file() {
     // Title
     assert_eq!(result.title, Some("Text Box Test Document".to_string()),);
 }
+
+/// End-to-end comment extraction through the public `convert_bytes` API.
+///
+/// Builds a DOCX in memory with a commented range and a `word/comments.xml`,
+/// then verifies the appended `# Comments` section in both markdown and plain
+/// text, and that it is absent without the flag.
+#[test]
+fn test_docx_extract_comments_end_to_end() {
+    use std::io::Write;
+    use zip::ZipWriter;
+    use zip::write::SimpleFileOptions;
+
+    let buf = Vec::new();
+    let mut zip = ZipWriter::new(Cursor::new(buf));
+    let opts = SimpleFileOptions::default();
+
+    zip.start_file("[Content_Types].xml", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+    )
+    .unwrap();
+
+    zip.start_file("_rels/.rels", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+    )
+    .unwrap();
+
+    // Body: a sentence with a commented range (id 1).
+    let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t xml:space="preserve">The report is due </w:t></w:r><w:commentRangeStart w:id="1"/><w:r><w:t>next Friday</w:t></w:r><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r><w:r><w:t>.</w:t></w:r></w:p></w:body></w:document>"#;
+    zip.start_file("word/document.xml", opts).unwrap();
+    zip.write_all(document_xml.as_bytes()).unwrap();
+
+    let comments_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:comment w:id="1" w:author="Reviewer" w:date="2024-03-01T12:00:00Z"><w:p><w:r><w:t>Can we move this up a week?</w:t></w:r></w:p></w:comment></w:comments>"#;
+    zip.start_file("word/comments.xml", opts).unwrap();
+    zip.write_all(comments_xml.as_bytes()).unwrap();
+
+    let data = zip.finish().unwrap().into_inner();
+
+    // Without the flag: no Comments section.
+    let plain_result =
+        anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    assert!(!plain_result.markdown.contains("# Comments"));
+    assert!(
+        plain_result
+            .markdown
+            .contains("The report is due next Friday.")
+    );
+
+    // With the flag: appended section in markdown and plain text.
+    let options = ConversionOptions {
+        extract_comments: true,
+        ..Default::default()
+    };
+    let result = anytomd::convert_bytes(&data, "docx", &options).unwrap();
+    assert!(
+        result.markdown.contains("# Comments"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(result.markdown.contains("## 1"));
+    assert!(
+        result
+            .markdown
+            .contains("- **author**: Reviewer (2024-03-01T12:00:00Z)")
+    );
+    assert!(
+        result
+            .markdown
+            .contains("- **comment**: Can we move this up a week?")
+    );
+    assert!(result.markdown.contains("- **source**: next Friday"));
+    // Body still present and the section is appended at the end.
+    let body = result.markdown.find("The report is due").unwrap();
+    let section = result.markdown.find("# Comments").unwrap();
+    assert!(body < section);
+    // Plain text mirrors the layout with markers stripped.
+    assert!(result.plain_text.contains("Comments\n"));
+    assert!(
+        result
+            .plain_text
+            .contains("author: Reviewer (2024-03-01T12:00:00Z)")
+    );
+    assert!(
+        result
+            .plain_text
+            .contains("comment: Can we move this up a week?")
+    );
+    assert!(result.plain_text.contains("source: next Friday"));
+    assert!(!result.plain_text.contains("# Comments"));
+}

--- a/tests/test_pptx.rs
+++ b/tests/test_pptx.rs
@@ -291,3 +291,71 @@ fn test_pptx_group_shape_convert_file() {
     // Title from first slide
     assert_eq!(result.title, Some("Group Shape Demo".to_string()),);
 }
+
+/// End-to-end PPTX comment extraction through the public `convert_bytes` API.
+///
+/// Builds a one-slide presentation with a legacy comment part and verifies the
+/// appended `# Comments` section uses the slide label as `source`.
+#[test]
+fn test_pptx_extract_comments_end_to_end() {
+    use std::io::Write;
+    use zip::ZipWriter;
+    use zip::write::SimpleFileOptions;
+
+    let buf = Vec::new();
+    let mut zip = ZipWriter::new(Cursor::new(buf));
+    let opts = SimpleFileOptions::default();
+
+    zip.start_file("[Content_Types].xml", opts).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#).unwrap();
+
+    zip.start_file("ppt/presentation.xml", opts).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>"#).unwrap();
+    zip.start_file("ppt/_rels/presentation.xml.rels", opts)
+        .unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#).unwrap();
+
+    zip.start_file("ppt/slides/slide1.xml", opts).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="1" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:txBody><a:p><a:r><a:t>Roadmap</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>"#).unwrap();
+
+    zip.start_file("ppt/slides/_rels/slide1.xml.rels", opts)
+        .unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdC" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="../comments/comment1.xml"/></Relationships>"#).unwrap();
+
+    zip.start_file("ppt/commentAuthors.xml", opts).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><p:cmAuthorLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cmAuthor id="0" name="Dana" initials="D"/></p:cmAuthorLst>"#).unwrap();
+    zip.start_file("ppt/comments/comment1.xml", opts).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><p:cmLst xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"><p:cm authorId="0" dt="2024-02-02T08:00:00Z" idx="1"><p:pos x="100" y="100"/><p:text>Reorder these milestones.</p:text></p:cm></p:cmLst>"#).unwrap();
+
+    let data = zip.finish().unwrap().into_inner();
+
+    // Without the flag: no Comments section.
+    let plain = anytomd::convert_bytes(&data, "pptx", &ConversionOptions::default()).unwrap();
+    assert!(!plain.markdown.contains("# Comments"));
+
+    let options = ConversionOptions {
+        extract_comments: true,
+        ..Default::default()
+    };
+    let result = anytomd::convert_bytes(&data, "pptx", &options).unwrap();
+    assert!(
+        result.markdown.contains("# Comments"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        result
+            .markdown
+            .contains("- **author**: Dana (2024-02-02T08:00:00Z)")
+    );
+    assert!(
+        result
+            .markdown
+            .contains("- **comment**: Reorder these milestones.")
+    );
+    assert!(result.markdown.contains("- **source**: Slide 1: Roadmap"));
+    // Slide content precedes the appended section.
+    let slide = result.markdown.find("## Slide 1").unwrap();
+    let section = result.markdown.find("# Comments").unwrap();
+    assert!(slide < section);
+}


### PR DESCRIPTION
## Summary

Adds opt-in extraction of document **comments** for DOCX and PPTX. When enabled,
a `# Comments` section is appended to the end of the converted output, capturing
the commenter, the comment body, and the source the comment is attached to.

Exposed two ways:

- **Library:** a new `ConversionOptions.extract_comments: bool` (default `false`).
- **CLI:** a new `--extract-comments` flag.

The flag is a no-op for formats without comments, so it is always safe to pass.

## Motivation

Comments carry review context — questions, decisions, action items — that is
otherwise lost on conversion. For LLM consumption (this crate's target), that
context is often as valuable as the body text. The feature is opt-in so default
output stays clean and existing behavior is unchanged.

## Output format

The appended section uses a fixed, flat structure (global 1‑based index in order
of appearance):

```markdown
# Comments

## 1
- **author**: Jane Smith (2024-01-15T09:30:00Z)
- **comment**: Please revise this paragraph.
- **source**: the quick brown fox

## 2
- **author**: Unknown
- **comment**: (reply) Agreed.
- **source**: jumped over
```

The section is appended to **both** `markdown` (formatted, above) and
`plain_text` (the same layout with all Markdown markers stripped:
`Comments` / `1` / `author:` / `comment:` / `source:`), consistent with the
crate's dual-output principle. With zero comments, the section is omitted
entirely.

## Behavior

**Common**
- `author` renders as `Name (date)`; the date is emitted verbatim (no parsing)
  and omitted when absent (no empty parentheses). A missing author becomes
  `Unknown`.
- The comment body is flattened to a single line (ASCII whitespace collapsed;
  meaningful non-ASCII spaces such as NBSP/ideographic space are preserved).
- Replies are flattened and prefixed with `(reply)`.
- Malformed or unresolved comment data is skipped with a `ConversionWarning`
  (best-effort), so it surfaces on stderr and trips `--strict`.

**DOCX**
- Reads `word/comments.xml` for author/date/body and `word/commentsExtended.xml`
  for reply threading.
- The commented-on `source` is the text inside the `commentRangeStart` …
  `commentRangeEnd` span, scanned across the body **and** any headers, footers,
  footnotes, and endnotes. Ordered by first anchor appearance in a fixed part
  sequence (body → headers → footers → footnotes → endnotes); comments with no
  anchor are appended last. Source is collapsed to one line and capped at 200
  characters.

**PPTX**
- Supports both the legacy (`commentAuthors.xml` + `comments/comment*.xml`) and
  modern (`authors.xml` + `comments/modernComment_*.xml`, threaded) schemes.
- PPTX comments are anchored to a point, not a text span, so the `source` is the
  slide label (`Slide N: Title`, or `Slide N` when the slide is untitled).

## Key changes

- `src/converter/comments.rs` (new): the `Comment` model, normalization helpers
  (`collapse_ws`, `cap_text`, `format_author`), and the `# Comments` Markdown /
  plain-text renderers (`append_comments`).
- `src/converter/docx.rs`: comment parsing (`comments.xml`,
  `commentsExtended.xml`, range collection across content parts) and assembly,
  wired into `convert_inner`.
- `src/converter/pptx.rs`: legacy + modern comment/author parsers and per-slide
  collection, wired into `convert_inner`.
- `src/converter/ooxml_utils.rs`: a shared `attr_value_unescaped` helper that
  XML-unescapes attribute values by local name.
- `src/zip_utils.rs`: `read_zip_text_lossy` for best-effort reads of optional
  sub-parts.
- `src/converter/mod.rs`, `src/lib.rs`, `src/runner.rs`: the
  `extract_comments` option, the async append sites, and the CLI flag.
- `README.md`, `TECH_SPEC.md`: documentation of the option, flag, output format,
  and per-format caveats.

`convert_inner` now returns the collected comments alongside the existing result
and pending-image data; the section is appended **after** image-placeholder
resolution in both the sync and async paths, so it never interferes with image
description.

## Robustness (review hardening)

A follow-up commit addresses correctness/robustness issues found in review, each
with a regression test:

- Self-closing text elements (`<w:t/>`, `<p:text/>`, `<a:t/>`) no longer leak
  stray text into comment bodies.
- DOCX `source` no longer leaks past its range: range markers are honored even
  inside skipped `mc:Choice` branches, text is captured only inside a run, and
  each range's source is byte-bounded so a malformed unclosed range cannot
  absorb the rest of the part.
- DOCX `w14:paraId` is taken only from top-level paragraphs, so a comment ending
  in a table doesn't break reply detection.
- A PPTX slide carrying both legacy and modern comment parts no longer
  double-reports (modern is preferred).
- A multi-line PPTX slide title no longer breaks the single-line `source` item.
- Author/date attributes are XML-unescaped (`R&amp;D` → `R&D`), matching body
  handling.
- A malformed (non-UTF-8) comment sub-part degrades gracefully instead of
  aborting the whole conversion.

## Testing

- Unit tests for every parser and helper (the comment model, range collection,
  author/reply parsing, edge cases) plus end-to-end tests through the public
  `convert_bytes` API for DOCX and PPTX, and CLI tests for the flag.
- Full verification: `cargo test` (all unit + integration suites), `cargo clippy
  -- -D warnings`, `cargo fmt --check`, `cargo doc --no-deps` (zero warnings),
  the `async` and `async-gemini` feature checks, the WASM target checks, and
  `cargo build --release` — all green.

## Notes / limitations

- The modern-PPTX comment schema is implemented from the MS-PPTX/ECMA-376
  specification and validated against synthetic fixtures; comment parsing is
  best-effort.
- `source` truncation is on a Unicode scalar boundary (panic-safe); multi-scalar
  grapheme clusters (e.g. flag/ZWJ emoji) may be split in the truncated tail.
- No new runtime dependencies; the feature is pure Rust and WASM-compatible.
