### PR TITLE
chore: release v1.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: crates.io publish
+
+# Publishes the crate to crates.io when a GitHub release is published. Pairs
+# with `npm-publish.yml` (same trigger), so a single `gh release create` fans
+# out to both registries. Publishing from a clean CI checkout — rather than a
+# local working tree — structurally prevents the untracked-file leak class that
+# affected v1.2.1 (see CLAUDE.md "Release Management").
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verify release tag matches Cargo.toml version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          echo "release tag: $GITHUB_REF_NAME (normalized: $tag) | Cargo.toml: $pkg"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::release tag 'v$tag' does not match Cargo.toml version '$pkg' — refusing to publish"
+            exit 1
+          fi
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,13 +298,16 @@ Follow all steps in order — do not skip any.
 3. **Bump version in `Cargo.toml`** — update `version = "..."` in `[package]`
 4. **Create PR** — branch `chore/release-vX.Y.Z`, commit message `chore: release vX.Y.Z`
 5. **Merge PR** — follow standard PR Merge Procedure above
-6. **Publish to crates.io** — from `main` after merge: `cargo publish`
-7. **Create GitHub release** — `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes --latest` (from `main` at the merge commit)
-8. **Verify sync** — confirm `cargo search anytomd` matches the GitHub release tag and `Cargo.toml`
+6. **Create the GitHub release (this triggers publishing)** — from `main` at the merge commit: `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes --latest`. Publishing is automated by GitHub Actions on the `release: published` event:
+   - `.github/workflows/release.yml` runs `cargo publish` to crates.io (after verifying the release tag matches `Cargo.toml`).
+   - `.github/workflows/npm-publish.yml` builds the WASM package and publishes it to npm.
+
+   Do **not** run `cargo publish` locally — the workflow publishes from a clean CI checkout, which structurally prevents the untracked-file leak class (see below). Requires the `CARGO_REGISTRY_TOKEN` and `NPM_TOKEN` repository secrets.
+7. **Verify both registries** — watch the runs (`gh run watch`), then confirm `cargo search anytomd` and `npm view anytomd version` both match the release tag and `Cargo.toml`. If a publish job fails (e.g. transient registry error), fix the cause and re-run the failed job from the Actions UI — the re-run reuses the release context.
 
 ### Pre-publish Safety Checks
 
-**Mandatory before step 6 (`cargo publish`).** Skipping these has historically leaked credentials — treat as non-negotiable.
+Publishing now happens from a clean CI checkout (step 6), so the untracked-working-tree leak class is structurally unreachable in the normal flow, and the `security` CI job still audits `cargo package --list` on every push/PR. The rules below remain **mandatory** for any manual `cargo publish` — an escape hatch only; the normal flow is the GitHub release. Skipping them has historically leaked credentials — treat as non-negotiable.
 
 1. **Working tree must be clean.** `git status --short` must produce no output. If untracked files appear (local IDE/tooling state, scratch files, generated artifacts), add them to `.gitignore` in a **separate PR** before publishing. Never proceed with `--allow-dirty` to "just get past it."
 2. **Audit the package contents.** Run:
@@ -318,9 +321,9 @@ Follow all steps in order — do not skip any.
 
 ### Version Sync Rules
 
-- **One version, three places**: `Cargo.toml` (source of truth) = crates.io = GitHub release tag
-- **Never publish to crates.io without a matching GitHub release** and vice versa
-- **Never manually edit crates.io metadata** — always go through `Cargo.toml` + `cargo publish`
+- **One version, four places**: `Cargo.toml` (source of truth) = crates.io = npm = GitHub release tag (the npm version is derived from `Cargo.toml` by `wasm-pack`)
+- **The GitHub release is the single publish trigger** — creating it publishes to crates.io and npm; never publish to either without the matching GitHub release
+- **Never manually edit crates.io metadata** — always go through `Cargo.toml` + the automated release workflow
 - **Tag format**: always `vX.Y.Z` (e.g., `v0.6.0`), created automatically by `gh release create`
 - **Cargo.lock**: committed to the repo for reproducible builds; updated automatically by version bump
 - If a release is partially completed (e.g., crates.io published but GitHub release missing), fix immediately — do not leave versions out of sync

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anytomd"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anytomd"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.89"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release **v1.3.0** (minor) and enable automated publishing via GitHub Actions.

This bundles two related changes needed to cut the release through CI:

1. **`chore: release v1.3.0`** — bump `Cargo.toml`/`Cargo.lock` from `1.2.2` → `1.3.0`.
2. **`ci: add automated crates.io publish on GitHub release`** — new `.github/workflows/release.yml`.

## Why minor

PR #91 added opt-in comment extraction for DOCX/PPTX: a new public `ConversionOptions.extract_comments` field and a `--extract-comments` CLI flag. New, non-breaking public API → SemVer **minor**.

## Automated publishing

`release.yml` runs `cargo publish` to crates.io on the `release: published` event — the same trigger as the existing `npm-publish.yml`, so one `gh release create vX.Y.Z` fans out to **both** crates.io and npm.

- **Leak-class prevention:** publishing from a clean CI checkout (not a local working tree) makes the untracked-file leak behind the v1.2.1 incident structurally unreachable — there is no local state for `cargo publish` to bundle.
- **Version guard:** the job fails if the release tag does not match the `Cargo.toml` version, enforcing the "one version, N places" rule.
- **Reproducible:** uses `cargo publish --locked`.
- **Requires** the `CARGO_REGISTRY_TOKEN` repository secret.

CLAUDE.md's Release Management section is updated to document the new flow.

## Key changes

- `Cargo.toml`, `Cargo.lock`: version `1.2.2` → `1.3.0`
- `.github/workflows/release.yml` (new): crates.io publish on release
- `CLAUDE.md`: release procedure now triggers automated publish; pre-publish safety checks reframed as a manual-escape-hatch concern

## Verification

`cargo build --locked` passes locally (Cargo.lock consistent with the bumped version). Full matrix + WASM + security checks run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)