### PR TITLE
fix(tables): preserve all columns in merged/layout tables (DOCX/HTML/PPTX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ A pure Rust tool and library that converts various document formats into Markdow
 
 | Format | Extensions | Notes |
 |--------|-----------|-------|
-| DOCX | `.docx` | Headings, tables, lists, bold/italic, hyperlinks, images, text boxes |
-| PPTX | `.pptx` | Slides, tables, speaker notes, images, group shapes |
+| DOCX | `.docx` | Headings, tables (incl. merged/layout tables), lists, bold/italic, hyperlinks, images, text boxes |
+| PPTX | `.pptx` | Slides, tables (incl. merged cells), speaker notes, images, group shapes |
 | XLSX | `.xlsx` | Multi-sheet, date/time handling, images |
 | XLS | `.xls` | Legacy Excel (via calamine) |
-| HTML | `.html`, `.htm` | Full DOM: headings, tables, lists, links, blockquotes, code blocks |
+| HTML | `.html`, `.htm` | Full DOM: headings, tables (incl. `colspan`/`rowspan`), lists, links, blockquotes, code blocks |
 | CSV | `.csv` | Converted to Markdown tables |
 | Jupyter Notebook | `.ipynb` | Markdown cells preserved, code cells in fenced blocks with language detection |
 | JSON | `.json` | Pretty-printed in fenced code blocks |
@@ -116,6 +116,24 @@ Data Overview
 
 > Note: Test multilingual rendering.
 ```
+
+### Tables and merged cells
+
+Plain, uniform tables become pipe-delimited Markdown tables. Tables that use
+merged cells (`gridSpan`/`vMerge` in DOCX, `colspan`/`rowspan` in HTML) — often
+used for page layout rather than tabular data — are rendered with a hybrid
+strategy that preserves all content instead of collapsing columns:
+
+- a full-width row (a single cell spanning every column) becomes a heading when
+  it is heading-styled, otherwise a bold paragraph;
+- a narrow-label + wide-value row becomes `**Label:** value`;
+- genuinely tabular regions (rows whose cells tile the full width) stay
+  pipe-delimited Markdown tables, with horizontal spans empty-filled and
+  vertical-merge continuation cells left blank;
+- nested tables are rendered in place as their own Markdown tables.
+
+PPTX tables are always rendered as Markdown tables; merged cells keep the
+correct column count and the spanning cell's text is not duplicated.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -119,20 +119,26 @@ Data Overview
 
 ### Tables and merged cells
 
-Plain, uniform tables become pipe-delimited Markdown tables. Tables that use
-merged cells (`gridSpan`/`vMerge` in DOCX, `colspan`/`rowspan` in HTML) — often
-used for page layout rather than tabular data — are rendered with a hybrid
-strategy that preserves all content instead of collapsing columns:
+Every table — plain, merged, or used for page layout — becomes a single
+pipe-delimited Markdown table of the table's true column count. Merged cells
+(`gridSpan`/`vMerge` in DOCX, `colspan`/`rowspan` in HTML) are handled so no
+content is lost:
 
-- a full-width row (a single cell spanning every column) becomes a heading when
-  it is heading-styled, otherwise a bold paragraph;
-- a narrow-label + wide-value row becomes `**Label:** value`;
-- genuinely tabular regions (rows whose cells tile the full width) stay
-  pipe-delimited Markdown tables, with horizontal spans empty-filled and
-  vertical-merge continuation cells left blank;
-- nested tables are rendered in place as their own Markdown tables.
+- a horizontally spanned cell puts its text in the first column it covers and
+  leaves the spanned-over columns empty (empty-fill);
+- a vertically merged (continuation) cell is left blank;
+- a full-width row (a single cell spanning every column) is kept as a normal
+  grid row, empty-filled to the table width — it is **not** turned into a heading
+  or a `**Label:** value` line.
 
-PPTX tables are always rendered as Markdown tables; merged cells keep the
+This is deliberately uniform: keeping a merged/layout table as one table (rather
+than splitting it into headings and field lines) gives downstream consumers,
+especially LLMs, a consistent structure. The one exception is a table that
+contains a **nested table** — a nested table cannot live inside a single Markdown
+cell, so such a table is linearized and each cell's text and nested table are
+emitted as standalone blocks.
+
+PPTX tables are likewise rendered as Markdown tables; merged cells keep the
 correct column count and the spanning cell's text is not duplicated.
 
 ## Installation

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -396,8 +396,6 @@ struct DocxTable {
     current_row: DocxRow,
     /// In-progress cell being accumulated.
     current_cell: DocxCell,
-    /// Number of paragraphs seen so far in the current cell.
-    cell_paragraph_count: usize,
     /// Whether a `<w:tr>` is currently open in this frame.
     in_row: bool,
     /// Whether a `<w:tc>` is currently open in this frame.
@@ -1042,7 +1040,6 @@ fn parse_document(
                         let frame = table_stack.last_mut().unwrap();
                         frame.in_cell = true;
                         frame.current_cell = DocxCell::default();
-                        frame.cell_paragraph_count = 0;
                     }
                     "p" if in_body => {
                         in_paragraph = true;
@@ -1401,7 +1398,6 @@ fn parse_document(
                                 kind: current_para_kind.clone(),
                                 is_table: false,
                             });
-                            frame.cell_paragraph_count += 1;
                         } else {
                             // Normal paragraph finalization
                             let is_list =

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -311,6 +311,12 @@ struct SavedParagraphState {
     in_num_pr: bool,
     current_num_id: Option<String>,
     current_ilvl: Option<u8>,
+    /// Whether the enclosing table frame had an open cell/row when the text box
+    /// was entered. Text-box content is a separate flow, so these are cleared on
+    /// entry (so the content does not leak into the surrounding cell) and
+    /// restored on exit.
+    table_in_cell: bool,
+    table_in_row: bool,
 }
 
 // ---- Table model ----
@@ -439,13 +445,23 @@ fn join_cell_blocks_plain(cell: &DocxCell) -> String {
 fn expand_row_to_grid(row: &DocxRow, grid_width: usize, plain: bool) -> Vec<String> {
     let mut cols: Vec<String> = Vec::with_capacity(grid_width);
     for c in &row.cells {
-        let span = c.grid_span.max(1);
-        let text = if c.v_merge == VMerge::Continue {
-            String::new()
-        } else if plain {
+        // Clamp the span to the columns still available so a malformed span value
+        // can never push the row past `grid_width`.
+        let remaining = grid_width.saturating_sub(cols.len());
+        let span = c.grid_span.max(1).min(remaining.max(1));
+        let content = if plain {
             join_cell_blocks_plain(c)
         } else {
             join_cell_blocks_md(c)
+        };
+        // A genuine vertical-merge continuation cell is empty in the source, so it
+        // renders empty. But if a continuation cell carries text (an orphan merge
+        // with no matching restart, or malformed input), keep it rather than
+        // silently dropping content.
+        let text = if c.v_merge == VMerge::Continue && content.is_empty() {
+            String::new()
+        } else {
+            content
         };
         cols.push(text);
         for _ in 1..span {
@@ -543,8 +559,10 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
                 if text.is_empty() {
                     continue;
                 }
-                // Heading if the banner's first paragraph is heading-styled.
-                let level = cell.blocks.first().and_then(|b| match b.kind {
+                // Heading if any of the banner's paragraphs is heading-styled
+                // (a banner cell often has a blank leading paragraph before the
+                // heading-styled title).
+                let level = cell.blocks.iter().find_map(|b| match b.kind {
                     ParagraphKind::Heading(l) => Some(l),
                     _ => None,
                 });
@@ -558,7 +576,9 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
             }
             DocxSegment::LabelValue(row) => {
                 let label = join_cell_blocks_md(&row.cells[0]);
-                let label = label.trim_end_matches(':').to_string();
+                // Strip a single trailing colon if present (we re-add exactly one);
+                // do not collapse multiple colons in labels like "Ratio::".
+                let label = label.strip_suffix(':').unwrap_or(&label).to_string();
                 let value_cell = &row.cells[1];
                 // Markdown: bold label + first value paragraph inline, rest on
                 // following lines (paragraph breaks preserved).
@@ -580,7 +600,7 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
                 }
                 // Plain: fully flattened — label line then each value paragraph.
                 let label_plain = join_cell_blocks_plain(&row.cells[0]);
-                let label_plain = label_plain.trim_end_matches(':');
+                let label_plain = label_plain.strip_suffix(':').unwrap_or(&label_plain);
                 plain.push_str(label_plain);
                 plain.push('\n');
                 for b in value_cell
@@ -604,21 +624,19 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
                 if docx_row_has_nested_table(row) {
                     // The row carries a nested table: emit each block in place —
                     // paragraphs as text, the nested table as a standalone block.
+                    // Every block is followed by a blank line so a sibling cell's
+                    // text after a nested table is not glued on as a table row.
                     for c in &row.cells {
                         for b in &c.blocks {
                             if b.md.trim().is_empty() {
                                 continue;
                             }
                             md.push_str(b.md.trim_end());
-                            md.push('\n');
-                            if !b.is_table {
-                                md.push('\n');
-                            }
+                            md.push_str("\n\n");
                             plain.push_str(b.plain.trim_end());
                             plain.push('\n');
                         }
                     }
-                    md.push('\n');
                     plain.push('\n');
                 } else {
                     // Small standalone GFM table padded to the row's own cell count.
@@ -647,14 +665,18 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
 /// authoritative). Falls back to the maximum over rows of the summed `grid_span`
 /// when the grid is absent or unparsed.
 fn docx_grid_width(t: &DocxTable) -> usize {
-    if t.grid_width > 0 {
-        return t.grid_width;
-    }
-    t.rows
-        .iter()
-        .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
-        .max()
-        .unwrap_or(0)
+    let width = if t.grid_width > 0 {
+        t.grid_width
+    } else {
+        t.rows
+            .iter()
+            .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
+            .max()
+            .unwrap_or(0)
+    };
+    // Bound the rendered grid width so an extreme span/gridCol count cannot drive
+    // unbounded column allocation downstream.
+    width.min(MAX_TABLE_COLS)
 }
 
 /// Whether a row's cells exactly tile the full grid width.
@@ -703,11 +725,13 @@ fn classify_docx_row(row: &DocxRow, grid_width: usize) -> DocxRowKind {
     // Label/value: narrow label (1 column) + wide value cell that genuinely
     // spans the remaining columns. The value must span at least 2 columns (so
     // `grid_width >= 3`); in a 2-column grid a `[1, 1]` row is an ordinary data
-    // row, not a label/value pair.
+    // row, not a label/value pair. The label cell must be non-empty — an empty
+    // label (e.g. a vertical-merge placeholder) would render a bare `**:**`.
     if cells.len() == 2
         && grid_width >= 3
         && cells[0].grid_span.max(1) == 1
         && cells[1].grid_span.max(1) == grid_width - 1
+        && !join_cell_blocks_md(&cells[0]).trim().is_empty()
     {
         return DocxRowKind::LabelValue;
     }
@@ -954,7 +978,16 @@ fn parse_document(
                             in_num_pr,
                             current_num_id: current_num_id.clone(),
                             current_ilvl,
+                            table_in_cell: table_stack.last().is_some_and(|f| f.in_cell),
+                            table_in_row: table_stack.last().is_some_and(|f| f.in_row),
                         });
+                        // A text box is a separate content flow: detach it from any
+                        // enclosing table cell so its paragraphs (and nested tables)
+                        // render to the main output rather than leaking into the cell.
+                        if let Some(frame) = table_stack.last_mut() {
+                            frame.in_cell = false;
+                            frame.in_row = false;
+                        }
                         // Reset paragraph-level state for text box content
                         in_paragraph = false;
                         in_run = false;
@@ -981,6 +1014,15 @@ fn parse_document(
                         continue;
                     }
                     _ => {}
+                }
+
+                // Table-property elements (gridCol/gridSpan/vMerge) may be serialized
+                // in long form (Start+End) rather than self-closing, so handle them here
+                // as well as in the Event::Empty arm.
+                if let Some(frame) = table_stack.last_mut()
+                    && apply_table_property(local_str, e, frame)
+                {
+                    continue;
                 }
 
                 match local_str {
@@ -1121,27 +1163,13 @@ fn parse_document(
                 let local = e.local_name();
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
 
+                if let Some(frame) = table_stack.last_mut()
+                    && apply_table_property(local_str, e, frame)
+                {
+                    continue;
+                }
+
                 match local_str {
-                    // `<w:gridCol>` inside `<w:tblGrid>` defines one grid column;
-                    // counting them yields the authoritative table width.
-                    "gridCol" if table_stack.last().is_some_and(|f| !f.in_row) => {
-                        table_stack.last_mut().unwrap().grid_width += 1;
-                    }
-                    // `<w:gridSpan w:val="N"/>` in `<w:tcPr>`: horizontal merge.
-                    "gridSpan" if table_stack.last().is_some_and(|f| f.in_cell) => {
-                        if let Some(n) = read_w_val(e).and_then(|v| v.parse::<usize>().ok()) {
-                            table_stack.last_mut().unwrap().current_cell.grid_span = n.max(1);
-                        }
-                    }
-                    // `<w:vMerge .../>` in `<w:tcPr>`: vertical merge. `w:val="restart"`
-                    // starts a merge; a bare `<w:vMerge/>` (or any other value) continues one.
-                    "vMerge" if table_stack.last().is_some_and(|f| f.in_cell) => {
-                        let v = match read_w_val(e).as_deref() {
-                            Some("restart") => VMerge::Restart,
-                            _ => VMerge::Continue,
-                        };
-                        table_stack.last_mut().unwrap().current_cell.v_merge = v;
-                    }
                     "pStyle" if in_para_properties => {
                         for attr in e.attributes().flatten() {
                             let local_name = attr.key.local_name();
@@ -1284,6 +1312,11 @@ fn parse_document(
                         in_num_pr = saved.in_num_pr;
                         current_num_id = saved.current_num_id;
                         current_ilvl = saved.current_ilvl;
+                        // Re-attach to the enclosing table cell, if any.
+                        if let Some(frame) = table_stack.last_mut() {
+                            frame.in_cell = saved.table_in_cell;
+                            frame.in_row = saved.table_in_row;
+                        }
                     }
                     continue;
                 }
@@ -1513,6 +1546,56 @@ fn parse_document(
     };
 
     (markdown, plain_text, title, warnings, image_infos)
+}
+
+/// Upper bound on table columns / cell span.
+///
+/// Caps `gridSpan`/`gridCol` so a malformed or hostile document with a huge span
+/// value cannot drive unbounded allocation when a row is expanded to the grid
+/// width. Far larger than any real table.
+const MAX_TABLE_COLS: usize = 4096;
+
+/// Parse a `<w:tblGrid>`/`<w:tcPr>` child element (`gridCol`, `gridSpan`,
+/// `vMerge`) into the current table frame.
+///
+/// Word may serialize these as self-closing (`Event::Empty`) or as separately
+/// closed (`Event::Start` + `Event::End`) elements, so both event arms call this.
+/// Returns `true` if the element was a recognized table-property element.
+fn apply_table_property(
+    local_str: &str,
+    e: &quick_xml::events::BytesStart,
+    frame: &mut DocxTable,
+) -> bool {
+    match local_str {
+        // `<w:gridCol>` inside `<w:tblGrid>` defines one grid column; counting
+        // them yields the authoritative table width.
+        "gridCol" if !frame.in_row => {
+            if frame.grid_width < MAX_TABLE_COLS {
+                frame.grid_width += 1;
+            }
+            true
+        }
+        // `<w:gridSpan w:val="N"/>` in `<w:tcPr>`: horizontal merge.
+        "gridSpan" if frame.in_cell => {
+            if let Some(n) = read_w_val(e).and_then(|v| v.parse::<usize>().ok()) {
+                frame.current_cell.grid_span = n.clamp(1, MAX_TABLE_COLS);
+            }
+            true
+        }
+        // `<w:vMerge .../>` in `<w:tcPr>`: vertical merge. `w:val="restart"` starts
+        // a merge; a bare `<w:vMerge/>` continues one. An explicit falsey value
+        // (`0`/`false`) means "not merged".
+        "vMerge" if frame.in_cell => {
+            let v = match read_w_val(e).as_deref() {
+                Some("restart") => VMerge::Restart,
+                Some(other) if other == "0" || other.eq_ignore_ascii_case("false") => VMerge::None,
+                _ => VMerge::Continue,
+            };
+            frame.current_cell.v_merge = v;
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Read the `w:val` attribute of an element, if present (namespace-agnostic).
@@ -3143,8 +3226,22 @@ mod tests {
 
     #[test]
     fn test_docx_expand_row_vmerge_continue_empty() {
-        let r = row(vec![cell("kept", 1, VMerge::Continue)]);
+        // A genuine vertical-merge continuation cell is empty in the source, so it
+        // renders empty.
+        let r = row(vec![DocxCell {
+            grid_span: 1,
+            v_merge: VMerge::Continue,
+            blocks: vec![],
+        }]);
         assert_eq!(expand_row_to_grid(&r, 1, false), vec![""]);
+    }
+
+    #[test]
+    fn test_docx_expand_row_vmerge_continue_with_text_preserved() {
+        // An orphan continuation cell that carries text (no matching restart, or
+        // malformed input) keeps its content rather than silently dropping it.
+        let r = row(vec![cell("kept", 1, VMerge::Continue)]);
+        assert_eq!(expand_row_to_grid(&r, 1, false), vec!["kept"]);
     }
 
     #[test]
@@ -3322,6 +3419,84 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(render_docx_table(&t), render_docx_table(&t));
+    }
+
+    #[test]
+    fn test_docx_render_label_value_double_colon_preserved() {
+        // A label ending in more than one colon must not have colons collapsed:
+        // only a single trailing colon is normalized away before re-adding one.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![
+                cell("Ratio::", 1, VMerge::None),
+                cell("v", 2, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let (md, _) = render_docx_table(&t);
+        assert!(md.contains("**Ratio::** v"), "md: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_banner_heading_not_first_block() {
+        // A banner cell whose heading-styled paragraph is preceded by an empty
+        // paragraph is still promoted to a heading.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![DocxCell {
+                    grid_span: 2,
+                    v_merge: VMerge::None,
+                    blocks: vec![
+                        DocxCellBlock {
+                            md: String::new(),
+                            plain: String::new(),
+                            kind: ParagraphKind::Normal,
+                            is_table: false,
+                        },
+                        DocxCellBlock {
+                            md: "Title".to_string(),
+                            plain: "Title".to_string(),
+                            kind: ParagraphKind::Heading(2),
+                            is_table: false,
+                        },
+                    ],
+                }]),
+                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
+            ],
+            ..Default::default()
+        };
+        let (md, _) = render_docx_table(&t);
+        assert!(md.contains("## Title"), "banner not promoted: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_empty_label_not_label_value() {
+        // A [empty label, wide value] row must not render a bare `**:**` artifact.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![
+                cell("", 1, VMerge::None),
+                cell("wide", 2, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let (md, _) = render_docx_table(&t);
+        assert!(!md.contains("**:**"), "empty-label artifact: {md}");
+    }
+
+    #[test]
+    fn test_docx_grid_width_bounded() {
+        // A pathological gridSpan cannot drive an unbounded grid width.
+        let t = DocxTable {
+            grid_width: 0,
+            rows: vec![row(vec![cell("x", 100_000_000, VMerge::None)])],
+            ..Default::default()
+        };
+        assert!(docx_grid_width(&t) <= MAX_TABLE_COLS);
+        // Expanding the row must not allocate beyond the bound.
+        let cols = expand_row_to_grid(&t.rows[0], docx_grid_width(&t), false);
+        assert!(cols.len() <= MAX_TABLE_COLS);
     }
 
     #[test]

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -517,13 +517,15 @@ fn render_docx_grid(rows: &[&DocxRow], grid_width: usize) -> (String, String) {
 /// is per-table (not per-row) by deliberate maintainer decision: consistency over
 /// prettiness. Only bugs within that path are fixed; the linearization is kept.
 ///
-/// `warnings` collects a [`WarningCode::ResourceLimitReached`] entry if the table
-/// is so large that rows are dropped to honor `MAX_TABLE_CELLS`.
+/// `warnings` collects [`WarningCode::ResourceLimitReached`] entries if the table
+/// is so large that rows (grid path) or blocks (linearize path) are dropped to
+/// honor `MAX_TABLE_CELLS`, or columns are dropped to honor `MAX_TABLE_COLS`.
 fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -> (String, String) {
     if table.rows.is_empty() {
         return (String::new(), String::new());
     }
 
+    let raw_width = docx_raw_grid_width(table);
     let grid_width = docx_grid_width(table);
     if grid_width == 0 {
         return (String::new(), String::new());
@@ -535,6 +537,18 @@ fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -
     // markdown. Excess rows are dropped — and, because dropping content must be
     // observable, a ResourceLimitReached warning is appended.
     if !table.rows.iter().any(docx_row_has_nested_table) {
+        // Capping the width drops trailing columns from the widest row(s); that
+        // must be observable too (mirrors the HTML converter's width-cap
+        // warning).
+        if raw_width > grid_width {
+            warnings.push(ConversionWarning {
+                code: WarningCode::ResourceLimitReached,
+                message: format!(
+                    "table row exceeded the {MAX_TABLE_COLS}-column limit; extra columns were dropped"
+                ),
+                location: None,
+            });
+        }
         let max_rows = (MAX_TABLE_CELLS / grid_width).max(1);
         if table.rows.len() > max_rows {
             warnings.push(ConversionWarning {
@@ -561,9 +575,16 @@ fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -
     // stream (both md and plain trim empty), so a block with non-empty md but
     // empty plain (e.g. an empty nested table) cannot inject a phantom blank line
     // into plain or a degenerate empty GFM table into md.
+    // The emitted blocks are bounded at MAX_TABLE_CELLS, the same budget the
+    // grid path enforces on its rendered cells: without it, a single nested
+    // table anywhere in an extreme-row-count table would divert rendering to
+    // this branch and bypass the cap entirely. Dropping blocks is observable
+    // via a ResourceLimitReached warning.
     let mut md = String::new();
     let mut plain = String::new();
-    for row in &table.rows {
+    let mut emitted_blocks = 0usize;
+    let mut truncated = false;
+    'rows: for row in &table.rows {
         for c in &row.cells {
             for b in &c.blocks {
                 let md_block = b.md.trim_end();
@@ -572,6 +593,11 @@ fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -
                 if md_block.trim_start().is_empty() && plain_block.trim_start().is_empty() {
                     continue;
                 }
+                if emitted_blocks >= MAX_TABLE_CELLS {
+                    truncated = true;
+                    break 'rows;
+                }
+                emitted_blocks += 1;
                 // Never emit a nested table whose rendered markdown is empty:
                 // it would otherwise contribute a degenerate empty GFM table.
                 if !(b.is_table && md_block.is_empty()) {
@@ -584,6 +610,15 @@ fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -
                 }
             }
         }
+    }
+    if truncated {
+        warnings.push(ConversionWarning {
+            code: WarningCode::ResourceLimitReached,
+            message: format!(
+                "table linearization truncated to {MAX_TABLE_CELLS} blocks (limit {MAX_TABLE_CELLS} cells)"
+            ),
+            location: None,
+        });
     }
 
     // Normalize each stream to end in exactly one newline, matching the contract
@@ -614,6 +649,19 @@ fn trim_to_single_trailing_newline(s: &str) -> String {
 
 // ---- Table classification ----
 
+/// Uncapped grid width of a table: the maximum of the declared `tblGrid` count
+/// and the widest row's summed spans. Callers compare this against the
+/// `MAX_TABLE_COLS`-capped width to detect (and warn about) dropped columns.
+fn docx_raw_grid_width(t: &DocxTable) -> usize {
+    let widest_row = t
+        .rows
+        .iter()
+        .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
+        .max()
+        .unwrap_or(0);
+    t.grid_width.max(widest_row)
+}
+
 /// Authoritative grid width of a table.
 ///
 /// The `<w:tblGrid>`/`<w:gridCol>` count is a FLOOR, not a ceiling: a row whose
@@ -623,16 +671,10 @@ fn trim_to_single_trailing_newline(s: &str) -> String {
 /// cell. (Word occasionally emits a `tblGrid` narrower than an actual row; taking
 /// the ceiling there silently dropped trailing cells.) The grid is still bounded
 /// by `MAX_TABLE_COLS` so an extreme span/gridCol count cannot drive unbounded
-/// column allocation downstream.
+/// column allocation downstream; [`render_docx_table`] warns when that bound
+/// actually drops columns.
 fn docx_grid_width(t: &DocxTable) -> usize {
-    let widest_row = t
-        .rows
-        .iter()
-        .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
-        .max()
-        .unwrap_or(0);
-    let width = t.grid_width.max(widest_row);
-    width.min(MAX_TABLE_COLS)
+    docx_raw_grid_width(t).min(MAX_TABLE_COLS)
 }
 
 /// Whether any cell in the row contains a nested-table block.
@@ -1197,9 +1239,16 @@ fn parse_document(
                         // A content-empty nested/inner table would render only to a
                         // degenerate skeleton (e.g. `|  |\n|---|`); skip it entirely
                         // so it never injects a phantom table into markdown or a
-                        // stray blank line into plain text.
+                        // stray blank line into plain text. Skip the render too:
+                        // a suppressed table contributes no output, so it must not
+                        // contribute a truncation warning either (a warning with
+                        // nothing visibly dropped would be a false positive).
                         let has_content = docx_table_has_content(&table);
-                        let (table_md, table_plain) = render_docx_table(&table, &mut warnings);
+                        let (table_md, table_plain) = if has_content {
+                            render_docx_table(&table, &mut warnings)
+                        } else {
+                            (String::new(), String::new())
+                        };
                         if table_stack.last().is_some_and(|f| f.in_cell) {
                             // Nested table: attach its rendered output to the
                             // enclosing cell as a block so it renders in place.
@@ -1416,7 +1465,9 @@ const MAX_TABLE_COLS: usize = 4096;
 /// `MAX_TABLE_COLS` bounds the width, but the row count is otherwise unbounded:
 /// a hostile document with millions of `<w:tr>` rows would materialize and escape
 /// a grid of arbitrary size. This caps the product so worst-case output stays a
-/// few MB. Mirrors the HTML converter's value. Far larger than any real table.
+/// few MB. The same budget bounds the blocks emitted by the nested-table
+/// linearization path, so routing a table through that path cannot bypass the
+/// cap. Mirrors the HTML converter's value. Far larger than any real table.
 const MAX_TABLE_CELLS: usize = 100_000;
 
 /// Parse a `<w:tblGrid>`/`<w:tcPr>` child element (`gridCol`, `gridSpan`,
@@ -3184,6 +3235,96 @@ mod tests {
         // Expanding the row must not allocate beyond the bound.
         let cols = expand_row_to_grid(&t.rows[0], docx_grid_width(&t), false);
         assert!(cols.len() <= MAX_TABLE_COLS);
+    }
+
+    #[test]
+    fn test_docx_linearize_path_blocks_capped_with_warning() {
+        // A nested table anywhere routes the whole table through the linearize
+        // path; the blocks it emits must honor MAX_TABLE_CELLS just like grid
+        // cells do, and dropping blocks must be observable.
+        let mut rows: Vec<DocxRow> = Vec::with_capacity(MAX_TABLE_CELLS + 2);
+        rows.push(row(vec![DocxCell {
+            grid_span: 1,
+            v_merge: VMerge::None,
+            blocks: vec![DocxCellBlock {
+                md: "| i |\n|---|".to_string(),
+                plain: "i".to_string(),
+                is_table: true,
+            }],
+        }]));
+        for i in 0..=MAX_TABLE_CELLS {
+            rows.push(row(vec![cell(&format!("r{i}"), 1, VMerge::None)]));
+        }
+        let t = DocxTable {
+            grid_width: 1,
+            rows,
+            ..Default::default()
+        };
+        let mut warnings = Vec::new();
+        let (md, plain) = render_docx_table(&t, &mut warnings);
+        assert!(md.contains("r0"), "early block missing");
+        let last = format!("r{MAX_TABLE_CELLS}");
+        assert!(
+            !md.contains(&last),
+            "linearized markdown not truncated: {} bytes",
+            md.len()
+        );
+        assert!(
+            !plain.contains(&last),
+            "linearized plain not truncated: {} bytes",
+            plain.len()
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == WarningCode::ResourceLimitReached),
+            "expected ResourceLimitReached warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn test_docx_overwide_row_columns_dropped_with_warning() {
+        // A row with more real cells than MAX_TABLE_COLS loses its trailing
+        // cells to the width cap; that drop must be observable (mirrors the
+        // HTML converter's width-cap warning).
+        let cells: Vec<DocxCell> = (0..MAX_TABLE_COLS + 5)
+            .map(|i| cell(&format!("c{i}"), 1, VMerge::None))
+            .collect();
+        let t = DocxTable {
+            grid_width: 0,
+            rows: vec![row(cells)],
+            ..Default::default()
+        };
+        let mut warnings = Vec::new();
+        let (md, _plain) = render_docx_table(&t, &mut warnings);
+        assert!(md.contains("c0"), "leading cell missing");
+        assert!(
+            !md.contains(&format!("c{MAX_TABLE_COLS}")),
+            "trailing cell beyond the width cap must be dropped"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == WarningCode::ResourceLimitReached),
+            "expected ResourceLimitReached warning, got: {warnings:?}"
+        );
+
+        // A table within the width bound must not warn.
+        let t_ok = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![
+                cell("a", 1, VMerge::None),
+                cell("b", 1, VMerge::None),
+                cell("c", 1, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let mut ok_warnings = Vec::new();
+        let _ = render_docx_table(&t_ok, &mut ok_warnings);
+        assert!(
+            ok_warnings.is_empty(),
+            "unexpected warning: {ok_warnings:?}"
+        );
     }
 
     #[test]

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -336,20 +336,18 @@ enum VMerge {
 /// One paragraph of content buffered inside a table cell.
 ///
 /// Cells may contain multiple paragraphs; keeping them as separate blocks lets
-/// the renderer preserve paragraph breaks when linearizing a layout table and
-/// detect heading-styled banner paragraphs. Markdown form retains bold/italic/
-/// link/image syntax; plain form has none.
+/// the renderer preserve paragraph breaks when linearizing a table that contains
+/// a nested table. Markdown form retains bold/italic/link/image syntax; plain
+/// form has none.
 #[derive(Debug, Clone)]
 struct DocxCellBlock {
     /// Markdown form of the paragraph (untrimmed, as produced by the run merge).
     md: String,
     /// Plain-text form of the paragraph (untrimmed, no markdown markers).
     plain: String,
-    /// The paragraph's block kind (used for banner heading detection).
-    kind: ParagraphKind,
     /// True when this block is a fully-rendered nested table (multi-line GFM).
-    /// Such blocks cannot be collapsed into a single grid cell, so any row that
-    /// contains one is linearized and the table is emitted as a standalone block.
+    /// Such blocks cannot be collapsed into a single grid cell, so any table that
+    /// contains one is linearized and the nested table emitted as a standalone block.
     is_table: bool,
 }
 
@@ -503,12 +501,16 @@ fn render_docx_grid(rows: &[&DocxRow], grid_width: usize) -> (String, String) {
 
 /// Render a buffered table to `(markdown, plain_text)`.
 ///
-/// Simple tables (uniform widths, no merges) use the historical GFM path
-/// unchanged. Spanned or layout tables are rendered with hybrid linearization:
-/// banner rows become headings/bold paragraphs, label/value rows become
-/// `**Label:** value`, contiguous tiling rows become GFM tables, and irregular
-/// rows become small standalone tables. Plain text linearizes fully (no markers)
-/// for non-grid segments and stays tab-separated for grid segments.
+/// Every table — uniform, merged, or layout — renders as a single GFM table of
+/// the authoritative grid width: horizontal spans are empty-filled, vertical-merge
+/// continuations are blank, and the first row is the header. This is deliberately
+/// uniform: a merged/layout table is kept as one table rather than being split
+/// into headings and `**Label:** value` lines, so structure stays consistent for
+/// downstream (LLM) consumers.
+///
+/// The one exception is a table that contains a nested table: a nested table
+/// cannot live inside a single GFM cell, so such a table is linearized — each
+/// cell's paragraphs and any nested table are emitted as standalone blocks.
 fn render_docx_table(table: &DocxTable) -> (String, String) {
     if table.rows.is_empty() {
         return (String::new(), String::new());
@@ -519,138 +521,30 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
         return (String::new(), String::new());
     }
 
-    // Simple table: exact historical behavior (row 0 header, flattened cells).
-    if docx_table_is_simple(table) {
-        let row_texts: Vec<Vec<String>> = table
-            .rows
-            .iter()
-            .map(|r| r.cells.iter().map(join_cell_blocks_md).collect())
-            .collect();
-        let row_texts_plain: Vec<Vec<String>> = table
-            .rows
-            .iter()
-            .map(|r| r.cells.iter().map(join_cell_blocks_plain).collect())
-            .collect();
-        let headers: Vec<&str> = row_texts[0].iter().map(|s| s.as_str()).collect();
-        let data: Vec<Vec<&str>> = row_texts[1..]
-            .iter()
-            .map(|r| r.iter().map(|s| s.as_str()).collect())
-            .collect();
-        let md = build_table(&headers, &data);
-        let headers_p: Vec<&str> = row_texts_plain[0].iter().map(|s| s.as_str()).collect();
-        let data_p: Vec<Vec<&str>> = row_texts_plain[1..]
-            .iter()
-            .map(|r| r.iter().map(|s| s.as_str()).collect())
-            .collect();
-        let plain = build_table_plain(&headers_p, &data_p);
-        return (md, plain);
+    // Common case: no nested tables → one empty-filled GFM grid.
+    if !table.rows.iter().any(docx_row_has_nested_table) {
+        let rows: Vec<&DocxRow> = table.rows.iter().collect();
+        return render_docx_grid(&rows, grid_width);
     }
 
-    // Hybrid path: classify rows and render each segment.
+    // A nested table cannot be a grid cell: linearize the whole table, emitting
+    // each cell's paragraphs and nested tables as standalone blocks in order.
     let mut md = String::new();
     let mut plain = String::new();
-    for seg in segment_docx_table(table, grid_width) {
-        match seg {
-            DocxSegment::Banner(row) => {
-                let cell = &row.cells[0];
-                let text = join_cell_blocks_md(cell);
-                if text.is_empty() {
+    for row in &table.rows {
+        for c in &row.cells {
+            for b in &c.blocks {
+                if b.md.trim().is_empty() {
                     continue;
                 }
-                // Heading if any of the banner's paragraphs is heading-styled
-                // (a banner cell often has a blank leading paragraph before the
-                // heading-styled title).
-                let level = cell.blocks.iter().find_map(|b| match b.kind {
-                    ParagraphKind::Heading(l) => Some(l),
-                    _ => None,
-                });
-                match level {
-                    Some(l) => md.push_str(&format_heading(l, &text)),
-                    None => md.push_str(&format!("**{text}**\n")),
-                }
-                md.push('\n');
-                plain.push_str(&join_cell_blocks_plain(cell));
-                plain.push_str("\n\n");
-            }
-            DocxSegment::LabelValue(row) => {
-                let label = join_cell_blocks_md(&row.cells[0]);
-                // Strip a single trailing colon if present (we re-add exactly one);
-                // do not collapse multiple colons in labels like "Ratio::".
-                let label = label.strip_suffix(':').unwrap_or(&label).to_string();
-                let value_cell = &row.cells[1];
-                // Markdown: bold label + first value paragraph inline, rest on
-                // following lines (paragraph breaks preserved).
-                let value_blocks: Vec<&DocxCellBlock> = value_cell
-                    .blocks
-                    .iter()
-                    .filter(|b| !b.md.trim().is_empty())
-                    .collect();
-                if value_blocks.is_empty() {
-                    md.push_str(&format!("**{label}:**\n\n"));
-                } else {
-                    md.push_str(&format!("**{label}:** {}\n", value_blocks[0].md.trim()));
-                    for b in &value_blocks[1..] {
-                        md.push('\n');
-                        md.push_str(b.md.trim());
-                        md.push('\n');
-                    }
-                    md.push('\n');
-                }
-                // Plain: fully flattened — label line then each value paragraph.
-                let label_plain = join_cell_blocks_plain(&row.cells[0]);
-                let label_plain = label_plain.strip_suffix(':').unwrap_or(&label_plain);
-                plain.push_str(label_plain);
+                md.push_str(b.md.trim_end());
+                md.push_str("\n\n");
+                plain.push_str(b.plain.trim_end());
                 plain.push('\n');
-                for b in value_cell
-                    .blocks
-                    .iter()
-                    .filter(|b| !b.plain.trim().is_empty())
-                {
-                    plain.push_str(b.plain.trim());
-                    plain.push('\n');
-                }
-                plain.push('\n');
-            }
-            DocxSegment::Grid(rows) => {
-                let (g_md, g_plain) = render_docx_grid(&rows, grid_width);
-                md.push_str(&g_md);
-                md.push('\n');
-                plain.push_str(&g_plain);
-                plain.push('\n');
-            }
-            DocxSegment::Fallback(row) => {
-                if docx_row_has_nested_table(row) {
-                    // The row carries a nested table: emit each block in place —
-                    // paragraphs as text, the nested table as a standalone block.
-                    // Every block is followed by a blank line so a sibling cell's
-                    // text after a nested table is not glued on as a table row.
-                    for c in &row.cells {
-                        for b in &c.blocks {
-                            if b.md.trim().is_empty() {
-                                continue;
-                            }
-                            md.push_str(b.md.trim_end());
-                            md.push_str("\n\n");
-                            plain.push_str(b.plain.trim_end());
-                            plain.push('\n');
-                        }
-                    }
-                    plain.push('\n');
-                } else {
-                    // Small standalone GFM table padded to the row's own cell count.
-                    let texts: Vec<String> = row.cells.iter().map(join_cell_blocks_md).collect();
-                    let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-                    md.push_str(&build_table(&refs, &[]));
-                    md.push('\n');
-                    let texts_p: Vec<String> =
-                        row.cells.iter().map(join_cell_blocks_plain).collect();
-                    let refs_p: Vec<&str> = texts_p.iter().map(|s| s.as_str()).collect();
-                    plain.push_str(&build_table_plain(&refs_p, &[]));
-                    plain.push('\n');
-                }
             }
         }
     }
+    plain.push('\n');
 
     (md, plain)
 }
@@ -680,130 +574,15 @@ fn docx_grid_width(t: &DocxTable) -> usize {
 /// Whether a row's cells exactly tile the full grid width.
 ///
 /// True when the summed `grid_span` over all cells equals `grid_width`.
-/// Continuation cells of a vertical merge still occupy their columns, so their
-/// `grid_span` is counted like any other cell's.
-fn docx_row_tiles(row: &DocxRow, grid_width: usize) -> bool {
-    grid_width > 0 && row.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>() == grid_width
-}
-
-/// The layout role of a table row, used to drive hybrid rendering.
-#[derive(Debug, Clone, PartialEq)]
-enum DocxRowKind {
-    /// A single cell spanning the full grid width (e.g. a section header).
-    Banner,
-    /// A narrow label cell followed by a wide value cell spanning the rest.
-    LabelValue,
-    /// Cells that exactly tile the grid width — eligible to stay a GFM table.
-    Tiling,
-    /// Anything else (irregular partial-width rows).
-    Fallback,
-}
-
 /// Whether any cell in the row contains a nested-table block.
 ///
-/// Such rows cannot be flattened into single grid cells, so they are linearized
-/// (classified `Fallback`) and their nested tables emitted as standalone blocks.
+/// A nested table cannot live inside a single GFM cell, so a table containing one
+/// is linearized (its cells' paragraphs and nested tables emitted as standalone
+/// blocks) rather than rendered as a grid.
 fn docx_row_has_nested_table(row: &DocxRow) -> bool {
     row.cells
         .iter()
         .any(|c| c.blocks.iter().any(|b| b.is_table))
-}
-
-/// Classify a single row by its cell layout. First matching rule wins.
-fn classify_docx_row(row: &DocxRow, grid_width: usize) -> DocxRowKind {
-    let cells = &row.cells;
-    // A row whose cell holds a nested table cannot become a grid cell; linearize.
-    if docx_row_has_nested_table(row) {
-        return DocxRowKind::Fallback;
-    }
-    // Banner: one cell covering the whole width.
-    if cells.len() == 1 && grid_width >= 1 && cells[0].grid_span.max(1) >= grid_width {
-        return DocxRowKind::Banner;
-    }
-    // Label/value: narrow label (1 column) + wide value cell that genuinely
-    // spans the remaining columns. The value must span at least 2 columns (so
-    // `grid_width >= 3`); in a 2-column grid a `[1, 1]` row is an ordinary data
-    // row, not a label/value pair. The label cell must be non-empty — an empty
-    // label (e.g. a vertical-merge placeholder) would render a bare `**:**`.
-    if cells.len() == 2
-        && grid_width >= 3
-        && cells[0].grid_span.max(1) == 1
-        && cells[1].grid_span.max(1) == grid_width - 1
-        && !join_cell_blocks_md(&cells[0]).trim().is_empty()
-    {
-        return DocxRowKind::LabelValue;
-    }
-    // Tiling: cells exactly fill the grid width.
-    if docx_row_tiles(row, grid_width) {
-        return DocxRowKind::Tiling;
-    }
-    DocxRowKind::Fallback
-}
-
-/// A contiguous run of rows sharing a layout role, ready to render as one block.
-#[derive(Debug)]
-enum DocxSegment<'a> {
-    /// A banner row → heading (if styled) or bold paragraph.
-    Banner(&'a DocxRow),
-    /// A label/value row → `**Label:** value`.
-    LabelValue(&'a DocxRow),
-    /// A maximal run of consecutive tiling rows → one GFM table (row 0 = header).
-    Grid(Vec<&'a DocxRow>),
-    /// An irregular row → its own small GFM table.
-    Fallback(&'a DocxRow),
-}
-
-/// Segment a table's rows into ordered render units.
-///
-/// Consecutive `Tiling` rows are coalesced into a single `Grid` segment; banner,
-/// label/value, and fallback rows are emitted as singletons in document order.
-/// Iterates an ordered slice only, so output ordering is deterministic.
-fn segment_docx_table<'a>(t: &'a DocxTable, grid_width: usize) -> Vec<DocxSegment<'a>> {
-    let mut segments: Vec<DocxSegment<'a>> = Vec::new();
-    let mut grid_run: Vec<&'a DocxRow> = Vec::new();
-
-    for row in &t.rows {
-        match classify_docx_row(row, grid_width) {
-            DocxRowKind::Tiling => grid_run.push(row),
-            kind => {
-                if !grid_run.is_empty() {
-                    segments.push(DocxSegment::Grid(std::mem::take(&mut grid_run)));
-                }
-                match kind {
-                    DocxRowKind::Banner => segments.push(DocxSegment::Banner(row)),
-                    DocxRowKind::LabelValue => segments.push(DocxSegment::LabelValue(row)),
-                    _ => segments.push(DocxSegment::Fallback(row)),
-                }
-            }
-        }
-    }
-    if !grid_run.is_empty() {
-        segments.push(DocxSegment::Grid(grid_run));
-    }
-    segments
-}
-
-/// Whether a table is "simple" and should use the plain GFM path unchanged.
-///
-/// True when no cell carries a horizontal or vertical merge and every row has the
-/// same cell count. Such tables render exactly as they did before hybrid handling,
-/// guaranteeing zero regression for ordinary data tables.
-fn docx_table_is_simple(t: &DocxTable) -> bool {
-    if t.rows.is_empty() {
-        return true;
-    }
-    // A nested table inside any cell forces the hybrid path so the inner table
-    // can be emitted as a standalone block rather than flattened into a cell.
-    if t.rows.iter().any(docx_row_has_nested_table) {
-        return false;
-    }
-    let width = t.rows[0].cells.len();
-    t.rows.iter().all(|r| {
-        r.cells.len() == width
-            && r.cells
-                .iter()
-                .all(|c| c.grid_span <= 1 && c.v_merge == VMerge::None)
-    })
 }
 
 /// Merge adjacent segments with the same formatting, then apply `wrap_formatting`
@@ -1346,7 +1125,6 @@ fn parse_document(
                                     DocxCellBlock {
                                         md: table_md,
                                         plain: table_plain,
-                                        kind: ParagraphKind::Normal,
                                         is_table: true,
                                     },
                                 );
@@ -1395,7 +1173,6 @@ fn parse_document(
                             frame.current_cell.blocks.push(DocxCellBlock {
                                 md: current_para_text.clone(),
                                 plain: current_para_text_plain.clone(),
-                                kind: current_para_kind.clone(),
                                 is_table: false,
                             });
                         } else {
@@ -2948,7 +2725,8 @@ mod tests {
     fn test_docx_table_gridspan_banner_preserves_all_columns() {
         // A full-width gridSpan banner over a two-column data row. The banner must
         // not collapse the table to one column: both "A" and "B" must survive.
-        // (This previously truncated every row to its first cell.)
+        // (This previously truncated every row to its first cell.) The whole table
+        // renders as one empty-filled GFM grid.
         let body = r#"<w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>Merged</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
         let doc = wrap_body(body);
         let data = build_test_docx(&doc, None, None);
@@ -2956,10 +2734,10 @@ mod tests {
         let result = converter
             .convert(&data, &ConversionOptions::default())
             .unwrap();
-        // The banner row linearizes to a bold paragraph (not a one-column table).
+        // The banner is the header row of the grid, empty-filled to full width.
         assert!(
-            result.markdown.contains("**Merged**"),
-            "banner missing: {}",
+            result.markdown.contains("| Merged |  |"),
+            "banner not an empty-filled header: {}",
             result.markdown
         );
         // The data row keeps both columns.
@@ -3004,7 +2782,6 @@ mod tests {
             blocks: vec![DocxCellBlock {
                 md: text.to_string(),
                 plain: text.to_string(),
-                kind: ParagraphKind::Normal,
                 is_table: false,
             }],
         }
@@ -3042,177 +2819,7 @@ mod tests {
         assert_eq!(docx_grid_width(&t), 3);
     }
 
-    #[test]
-    fn test_docx_row_tiles_exact() {
-        let r = row(vec![
-            cell("a", 1, VMerge::None),
-            cell("b", 1, VMerge::None),
-            cell("c", 1, VMerge::None),
-        ]);
-        assert!(docx_row_tiles(&r, 3));
-    }
-
-    #[test]
-    fn test_docx_row_tiles_banner_full_width() {
-        // A single full-width cell technically tiles; banner classification (which
-        // is checked before tiling) is what distinguishes it.
-        let r = row(vec![cell("a", 3, VMerge::None)]);
-        assert!(docx_row_tiles(&r, 3));
-    }
-
-    #[test]
-    fn test_docx_row_tiles_short_false() {
-        let r = row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]);
-        assert!(!docx_row_tiles(&r, 3));
-    }
-
-    #[test]
-    fn test_classify_docx_row_banner() {
-        let r = row(vec![cell("Section", 5, VMerge::None)]);
-        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::Banner);
-    }
-
-    #[test]
-    fn test_classify_docx_row_label_value() {
-        let r = row(vec![
-            cell("Label", 1, VMerge::None),
-            cell("Value", 4, VMerge::None),
-        ]);
-        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::LabelValue);
-    }
-
-    #[test]
-    fn test_classify_docx_row_tiling() {
-        let r = row(vec![
-            cell("a", 1, VMerge::None),
-            cell("b", 1, VMerge::None),
-            cell("c", 1, VMerge::None),
-        ]);
-        assert_eq!(classify_docx_row(&r, 3), DocxRowKind::Tiling);
-    }
-
-    #[test]
-    fn test_classify_docx_row_fallback() {
-        // Two narrow cells in a 5-column grid: neither banner, label/value, nor tiling.
-        let r = row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]);
-        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::Fallback);
-    }
-
-    #[test]
-    fn test_segment_docx_banner_then_grid() {
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![
-                row(vec![cell("Banner", 3, VMerge::None)]),
-                row(vec![
-                    cell("a", 1, VMerge::None),
-                    cell("b", 1, VMerge::None),
-                    cell("c", 1, VMerge::None),
-                ]),
-                row(vec![
-                    cell("d", 1, VMerge::None),
-                    cell("e", 1, VMerge::None),
-                    cell("f", 1, VMerge::None),
-                ]),
-            ],
-            ..Default::default()
-        };
-        let segs = segment_docx_table(&t, 3);
-        assert_eq!(segs.len(), 2);
-        assert!(matches!(segs[0], DocxSegment::Banner(_)));
-        match &segs[1] {
-            DocxSegment::Grid(rows) => assert_eq!(rows.len(), 2),
-            other => panic!("expected Grid, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_segment_docx_grid_split_by_labelvalue() {
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![
-                row(vec![
-                    cell("a", 1, VMerge::None),
-                    cell("b", 1, VMerge::None),
-                    cell("c", 1, VMerge::None),
-                ]),
-                row(vec![cell("L", 1, VMerge::None), cell("V", 2, VMerge::None)]),
-                row(vec![
-                    cell("d", 1, VMerge::None),
-                    cell("e", 1, VMerge::None),
-                    cell("f", 1, VMerge::None),
-                ]),
-            ],
-            ..Default::default()
-        };
-        let segs = segment_docx_table(&t, 3);
-        assert_eq!(segs.len(), 3);
-        assert!(matches!(segs[0], DocxSegment::Grid(_)));
-        assert!(matches!(segs[1], DocxSegment::LabelValue(_)));
-        assert!(matches!(segs[2], DocxSegment::Grid(_)));
-    }
-
-    #[test]
-    fn test_docx_table_is_simple_true() {
-        let t = DocxTable {
-            grid_width: 2,
-            rows: vec![
-                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
-                row(vec![cell("c", 1, VMerge::None), cell("d", 1, VMerge::None)]),
-            ],
-            ..Default::default()
-        };
-        assert!(docx_table_is_simple(&t));
-    }
-
-    #[test]
-    fn test_docx_table_is_simple_false_gridspan() {
-        let t = DocxTable {
-            grid_width: 2,
-            rows: vec![row(vec![cell("a", 2, VMerge::None)])],
-            ..Default::default()
-        };
-        assert!(!docx_table_is_simple(&t));
-    }
-
-    #[test]
-    fn test_docx_table_is_simple_false_vmerge() {
-        let t = DocxTable {
-            grid_width: 1,
-            rows: vec![row(vec![cell("a", 1, VMerge::Restart)])],
-            ..Default::default()
-        };
-        assert!(!docx_table_is_simple(&t));
-    }
-
-    #[test]
-    fn test_docx_table_is_simple_false_ragged() {
-        let t = DocxTable {
-            grid_width: 2,
-            rows: vec![
-                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
-                row(vec![cell("c", 1, VMerge::None)]),
-            ],
-            ..Default::default()
-        };
-        assert!(!docx_table_is_simple(&t));
-    }
-
-    // ---- Hybrid render unit tests ----
-
-    /// Build a cell whose first paragraph carries the given kind (for banner tests).
-    fn cell_kind(text: &str, grid_span: usize, kind: ParagraphKind) -> DocxCell {
-        DocxCell {
-            grid_span,
-            v_merge: VMerge::None,
-            blocks: vec![DocxCellBlock {
-                md: text.to_string(),
-                plain: text.to_string(),
-                kind,
-                is_table: false,
-            }],
-        }
-    }
+    // ---- Grid render unit tests ----
 
     #[test]
     fn test_docx_expand_row_to_grid_hspan() {
@@ -3241,36 +2848,34 @@ mod tests {
     }
 
     #[test]
-    fn test_docx_render_banner_bold() {
-        // Banner with a Normal paragraph → bold paragraph, not a heading.
+    fn test_docx_render_full_width_banner_is_grid_row() {
+        // A full-width "banner" row is kept as a grid row (empty-filled), not
+        // linearized into a heading or bold paragraph.
         let t = DocxTable {
             grid_width: 3,
-            rows: vec![row(vec![cell("Section Header", 3, VMerge::None)])],
+            rows: vec![
+                row(vec![cell("Section Header", 3, VMerge::None)]),
+                row(vec![
+                    cell("A", 1, VMerge::None),
+                    cell("B", 1, VMerge::None),
+                    cell("C", 1, VMerge::None),
+                ]),
+            ],
             ..Default::default()
         };
         let (md, _plain) = render_docx_table(&t);
-        assert!(md.contains("**Section Header**"), "md: {md}");
-        assert!(!md.contains("# Section Header"), "md: {md}");
-        assert!(!md.contains('|'), "banner must not be a table: {md}");
+        // One GFM table: the banner is the header row, empty-filled.
+        assert!(md.contains("| Section Header |  |  |"), "md: {md}");
+        assert!(md.contains("| A | B | C |"), "md: {md}");
+        // No heading/bold linearization.
+        assert!(!md.contains('#'), "md: {md}");
+        assert!(!md.contains("**"), "md: {md}");
     }
 
     #[test]
-    fn test_docx_render_banner_heading() {
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![row(vec![cell_kind(
-                "Section Header",
-                3,
-                ParagraphKind::Heading(2),
-            )])],
-            ..Default::default()
-        };
-        let (md, _plain) = render_docx_table(&t);
-        assert!(md.contains("## Section Header"), "md: {md}");
-    }
-
-    #[test]
-    fn test_docx_render_label_value() {
+    fn test_docx_render_label_value_kept_as_grid_row() {
+        // A narrow-label + wide-value row stays a grid row (empty-filled), not a
+        // `**Label:** value` line.
         let t = DocxTable {
             grid_width: 3,
             rows: vec![row(vec![
@@ -3280,47 +2885,32 @@ mod tests {
             ..Default::default()
         };
         let (md, _plain) = render_docx_table(&t);
-        assert!(md.contains("**Date:** Monday"), "md: {md}");
+        assert!(md.contains("| Date | Monday |  |"), "md: {md}");
+        assert!(!md.contains("**Date:**"), "md: {md}");
     }
 
     #[test]
-    fn test_docx_render_label_value_existing_colon_not_doubled() {
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![row(vec![
-                cell("Date:", 1, VMerge::None),
-                cell("Monday", 2, VMerge::None),
-            ])],
-            ..Default::default()
-        };
-        let (md, _plain) = render_docx_table(&t);
-        assert!(md.contains("**Date:** Monday"), "md: {md}");
-        assert!(!md.contains("Date::"), "colon doubled: {md}");
-    }
-
-    #[test]
-    fn test_docx_render_grid_region_full_width() {
-        // A banner over a 3-column data grid: the grid keeps all columns.
+    fn test_docx_render_data_table_spanning_row_keeps_columns() {
+        // A data table with a header row and a spanning row keeps all columns as
+        // one GFM table (the regression the review flagged).
         let t = DocxTable {
             grid_width: 3,
             rows: vec![
-                row(vec![cell("Banner", 3, VMerge::None)]),
                 row(vec![
                     cell("A", 1, VMerge::None),
                     cell("B", 1, VMerge::None),
                     cell("C", 1, VMerge::None),
                 ]),
                 row(vec![
-                    cell("1", 1, VMerge::None),
-                    cell("2", 1, VMerge::None),
-                    cell("3", 1, VMerge::None),
+                    cell("x", 1, VMerge::None),
+                    cell("spans", 2, VMerge::None),
                 ]),
             ],
             ..Default::default()
         };
         let (md, _plain) = render_docx_table(&t);
         assert!(md.contains("| A | B | C |"), "md: {md}");
-        assert!(md.contains("| 1 | 2 | 3 |"), "md: {md}");
+        assert!(md.contains("| x | spans |  |"), "md: {md}");
     }
 
     #[test]
@@ -3348,11 +2938,14 @@ mod tests {
 
     #[test]
     fn test_docx_render_pipe_in_cell_escaped() {
-        // A literal pipe inside a hybrid-grid cell must be escaped by build_table.
+        // A literal pipe inside a grid cell must be escaped by build_table.
         let t = DocxTable {
             grid_width: 2,
             rows: vec![
-                row(vec![cell("Banner", 2, VMerge::None)]),
+                row(vec![
+                    cell("h1", 1, VMerge::None),
+                    cell("h2", 1, VMerge::None),
+                ]),
                 row(vec![
                     cell("a|b", 1, VMerge::None),
                     cell("c", 1, VMerge::None),
@@ -3365,17 +2958,12 @@ mod tests {
     }
 
     #[test]
-    fn test_docx_plain_linearized_flattened() {
-        // Plain text: banner + label/value linearize with NO markers; grid region
-        // stays tab-separated.
+    fn test_docx_plain_grid_tab_separated() {
+        // Plain text for a merged/layout table is tab-separated, empty-filled.
         let t = DocxTable {
             grid_width: 3,
             rows: vec![
                 row(vec![cell("Section", 3, VMerge::None)]),
-                row(vec![
-                    cell("Field", 1, VMerge::None),
-                    cell("Value", 2, VMerge::None),
-                ]),
                 row(vec![
                     cell("A", 1, VMerge::None),
                     cell("B", 1, VMerge::None),
@@ -3386,13 +2974,8 @@ mod tests {
         };
         let (_md, plain) = render_docx_table(&t);
         assert!(plain.contains("Section"), "plain: {plain}");
-        assert!(plain.contains("Field"), "plain: {plain}");
-        assert!(plain.contains("Value"), "plain: {plain}");
-        // No markdown markers in linearized plain text.
-        assert!(!plain.contains("**"), "plain has bold markers: {plain}");
-        assert!(!plain.contains("**Field:**"), "plain: {plain}");
-        // Grid region is tab-separated.
-        assert!(plain.contains("A\tB\tC"), "plain grid not tabbed: {plain}");
+        assert!(!plain.contains("**"), "plain has markers: {plain}");
+        assert!(plain.contains("A\tB\tC"), "plain not tabbed: {plain}");
     }
 
     #[test]
@@ -3415,70 +2998,6 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(render_docx_table(&t), render_docx_table(&t));
-    }
-
-    #[test]
-    fn test_docx_render_label_value_double_colon_preserved() {
-        // A label ending in more than one colon must not have colons collapsed:
-        // only a single trailing colon is normalized away before re-adding one.
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![row(vec![
-                cell("Ratio::", 1, VMerge::None),
-                cell("v", 2, VMerge::None),
-            ])],
-            ..Default::default()
-        };
-        let (md, _) = render_docx_table(&t);
-        assert!(md.contains("**Ratio::** v"), "md: {md}");
-    }
-
-    #[test]
-    fn test_docx_render_banner_heading_not_first_block() {
-        // A banner cell whose heading-styled paragraph is preceded by an empty
-        // paragraph is still promoted to a heading.
-        let t = DocxTable {
-            grid_width: 2,
-            rows: vec![
-                row(vec![DocxCell {
-                    grid_span: 2,
-                    v_merge: VMerge::None,
-                    blocks: vec![
-                        DocxCellBlock {
-                            md: String::new(),
-                            plain: String::new(),
-                            kind: ParagraphKind::Normal,
-                            is_table: false,
-                        },
-                        DocxCellBlock {
-                            md: "Title".to_string(),
-                            plain: "Title".to_string(),
-                            kind: ParagraphKind::Heading(2),
-                            is_table: false,
-                        },
-                    ],
-                }]),
-                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
-            ],
-            ..Default::default()
-        };
-        let (md, _) = render_docx_table(&t);
-        assert!(md.contains("## Title"), "banner not promoted: {md}");
-    }
-
-    #[test]
-    fn test_docx_render_empty_label_not_label_value() {
-        // A [empty label, wide value] row must not render a bare `**:**` artifact.
-        let t = DocxTable {
-            grid_width: 3,
-            rows: vec![row(vec![
-                cell("", 1, VMerge::None),
-                cell("wide", 2, VMerge::None),
-            ])],
-            ..Default::default()
-        };
-        let (md, _) = render_docx_table(&t);
-        assert!(!md.contains("**:**"), "empty-label artifact: {md}");
     }
 
     #[test]

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -313,6 +313,477 @@ struct SavedParagraphState {
     current_ilvl: Option<u8>,
 }
 
+// ---- Table model ----
+
+/// Vertical-merge state of a table cell (`<w:vMerge>`).
+#[derive(Debug, Clone, Default, PartialEq)]
+enum VMerge {
+    /// Not vertically merged.
+    #[default]
+    None,
+    /// Top cell of a vertical merge (`<w:vMerge w:val="restart"/>`).
+    Restart,
+    /// Continuation cell of a vertical merge (a bare `<w:vMerge/>`).
+    Continue,
+}
+
+/// One paragraph of content buffered inside a table cell.
+///
+/// Cells may contain multiple paragraphs; keeping them as separate blocks lets
+/// the renderer preserve paragraph breaks when linearizing a layout table and
+/// detect heading-styled banner paragraphs. Markdown form retains bold/italic/
+/// link/image syntax; plain form has none.
+#[derive(Debug, Clone)]
+struct DocxCellBlock {
+    /// Markdown form of the paragraph (untrimmed, as produced by the run merge).
+    md: String,
+    /// Plain-text form of the paragraph (untrimmed, no markdown markers).
+    plain: String,
+    /// The paragraph's block kind (used for banner heading detection).
+    kind: ParagraphKind,
+    /// True when this block is a fully-rendered nested table (multi-line GFM).
+    /// Such blocks cannot be collapsed into a single grid cell, so any row that
+    /// contains one is linearized and the table is emitted as a standalone block.
+    is_table: bool,
+}
+
+/// A buffered table cell with horizontal/vertical span info and content blocks.
+#[derive(Debug, Clone)]
+struct DocxCell {
+    /// Grid columns this cell spans (`<w:gridSpan w:val>`); always at least 1.
+    grid_span: usize,
+    /// Vertical-merge state (`<w:vMerge>`).
+    v_merge: VMerge,
+    /// Content paragraphs, in document order.
+    blocks: Vec<DocxCellBlock>,
+}
+
+impl Default for DocxCell {
+    fn default() -> Self {
+        Self {
+            grid_span: 1,
+            v_merge: VMerge::None,
+            blocks: Vec::new(),
+        }
+    }
+}
+
+/// A buffered table row.
+#[derive(Debug, Clone, Default)]
+struct DocxRow {
+    /// Cells in document order.
+    cells: Vec<DocxCell>,
+}
+
+/// A fully buffered table plus its authoritative grid width.
+///
+/// Tables are buffered in full before rendering because layout classification
+/// needs every row in hand. A stack of these supports nested tables: an inner
+/// `<w:tbl>` pushes a new frame and pops on its end tag.
+#[derive(Debug, Clone, Default)]
+struct DocxTable {
+    /// Completed rows, in document order.
+    rows: Vec<DocxRow>,
+    /// Grid column count from `<w:tblGrid>`/`<w:gridCol>` (0 if absent/unparsed).
+    grid_width: usize,
+    /// In-progress row being accumulated.
+    current_row: DocxRow,
+    /// In-progress cell being accumulated.
+    current_cell: DocxCell,
+    /// Number of paragraphs seen so far in the current cell.
+    cell_paragraph_count: usize,
+    /// Whether a `<w:tr>` is currently open in this frame.
+    in_row: bool,
+    /// Whether a `<w:tc>` is currently open in this frame.
+    in_cell: bool,
+}
+
+/// Flatten a cell's paragraph blocks into one Markdown string.
+///
+/// Reproduces the historical join: paragraphs are trimmed and concatenated, with
+/// a single space inserted before each non-empty paragraph after the first; the
+/// whole result is then trimmed.
+fn join_cell_blocks_md(cell: &DocxCell) -> String {
+    let mut s = String::new();
+    for (i, b) in cell.blocks.iter().enumerate() {
+        if i > 0 && !b.md.is_empty() {
+            s.push(' ');
+        }
+        s.push_str(b.md.trim());
+    }
+    s.trim().to_string()
+}
+
+/// Flatten a cell's paragraph blocks into one plain-text string.
+///
+/// Mirrors [`join_cell_blocks_md`] but uses the plain form and checks plain
+/// emptiness for space insertion (matching the historical plain-text join).
+fn join_cell_blocks_plain(cell: &DocxCell) -> String {
+    let mut s = String::new();
+    for (i, b) in cell.blocks.iter().enumerate() {
+        if i > 0 && !b.plain.is_empty() {
+            s.push(' ');
+        }
+        s.push_str(b.plain.trim());
+    }
+    s.trim().to_string()
+}
+
+/// Expand a row's cells across `grid_width` columns for GFM rendering.
+///
+/// A cell with `grid_span = k` places its (joined) text in the first of its `k`
+/// columns and leaves the other `k - 1` empty (empty-fill). Vertical-merge
+/// continuation cells render empty. The `plain` flag selects the plain-text
+/// join. The result always has exactly `grid_width` entries (truncated/padded if
+/// the row's spans do not sum to the width).
+fn expand_row_to_grid(row: &DocxRow, grid_width: usize, plain: bool) -> Vec<String> {
+    let mut cols: Vec<String> = Vec::with_capacity(grid_width);
+    for c in &row.cells {
+        let span = c.grid_span.max(1);
+        let text = if c.v_merge == VMerge::Continue {
+            String::new()
+        } else if plain {
+            join_cell_blocks_plain(c)
+        } else {
+            join_cell_blocks_md(c)
+        };
+        cols.push(text);
+        for _ in 1..span {
+            cols.push(String::new());
+        }
+    }
+    cols.resize(grid_width, String::new());
+    cols
+}
+
+/// Build a GFM table (markdown + plain) from a slice of rows, expanding spans.
+///
+/// The first row supplies the header; remaining rows are data. Each row is
+/// expanded to `grid_width` columns via [`expand_row_to_grid`].
+fn render_docx_grid(rows: &[&DocxRow], grid_width: usize) -> (String, String) {
+    let md_rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| expand_row_to_grid(r, grid_width, false))
+        .collect();
+    let plain_rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| expand_row_to_grid(r, grid_width, true))
+        .collect();
+
+    let headers: Vec<&str> = md_rows[0].iter().map(|s| s.as_str()).collect();
+    let data: Vec<Vec<&str>> = md_rows[1..]
+        .iter()
+        .map(|r| r.iter().map(|s| s.as_str()).collect())
+        .collect();
+    let md = build_table(&headers, &data);
+
+    let headers_p: Vec<&str> = plain_rows[0].iter().map(|s| s.as_str()).collect();
+    let data_p: Vec<Vec<&str>> = plain_rows[1..]
+        .iter()
+        .map(|r| r.iter().map(|s| s.as_str()).collect())
+        .collect();
+    let plain = build_table_plain(&headers_p, &data_p);
+
+    (md, plain)
+}
+
+/// Render a buffered table to `(markdown, plain_text)`.
+///
+/// Simple tables (uniform widths, no merges) use the historical GFM path
+/// unchanged. Spanned or layout tables are rendered with hybrid linearization:
+/// banner rows become headings/bold paragraphs, label/value rows become
+/// `**Label:** value`, contiguous tiling rows become GFM tables, and irregular
+/// rows become small standalone tables. Plain text linearizes fully (no markers)
+/// for non-grid segments and stays tab-separated for grid segments.
+fn render_docx_table(table: &DocxTable) -> (String, String) {
+    if table.rows.is_empty() {
+        return (String::new(), String::new());
+    }
+
+    let grid_width = docx_grid_width(table);
+    if grid_width == 0 {
+        return (String::new(), String::new());
+    }
+
+    // Simple table: exact historical behavior (row 0 header, flattened cells).
+    if docx_table_is_simple(table) {
+        let row_texts: Vec<Vec<String>> = table
+            .rows
+            .iter()
+            .map(|r| r.cells.iter().map(join_cell_blocks_md).collect())
+            .collect();
+        let row_texts_plain: Vec<Vec<String>> = table
+            .rows
+            .iter()
+            .map(|r| r.cells.iter().map(join_cell_blocks_plain).collect())
+            .collect();
+        let headers: Vec<&str> = row_texts[0].iter().map(|s| s.as_str()).collect();
+        let data: Vec<Vec<&str>> = row_texts[1..]
+            .iter()
+            .map(|r| r.iter().map(|s| s.as_str()).collect())
+            .collect();
+        let md = build_table(&headers, &data);
+        let headers_p: Vec<&str> = row_texts_plain[0].iter().map(|s| s.as_str()).collect();
+        let data_p: Vec<Vec<&str>> = row_texts_plain[1..]
+            .iter()
+            .map(|r| r.iter().map(|s| s.as_str()).collect())
+            .collect();
+        let plain = build_table_plain(&headers_p, &data_p);
+        return (md, plain);
+    }
+
+    // Hybrid path: classify rows and render each segment.
+    let mut md = String::new();
+    let mut plain = String::new();
+    for seg in segment_docx_table(table, grid_width) {
+        match seg {
+            DocxSegment::Banner(row) => {
+                let cell = &row.cells[0];
+                let text = join_cell_blocks_md(cell);
+                if text.is_empty() {
+                    continue;
+                }
+                // Heading if the banner's first paragraph is heading-styled.
+                let level = cell.blocks.first().and_then(|b| match b.kind {
+                    ParagraphKind::Heading(l) => Some(l),
+                    _ => None,
+                });
+                match level {
+                    Some(l) => md.push_str(&format_heading(l, &text)),
+                    None => md.push_str(&format!("**{text}**\n")),
+                }
+                md.push('\n');
+                plain.push_str(&join_cell_blocks_plain(cell));
+                plain.push_str("\n\n");
+            }
+            DocxSegment::LabelValue(row) => {
+                let label = join_cell_blocks_md(&row.cells[0]);
+                let label = label.trim_end_matches(':').to_string();
+                let value_cell = &row.cells[1];
+                // Markdown: bold label + first value paragraph inline, rest on
+                // following lines (paragraph breaks preserved).
+                let value_blocks: Vec<&DocxCellBlock> = value_cell
+                    .blocks
+                    .iter()
+                    .filter(|b| !b.md.trim().is_empty())
+                    .collect();
+                if value_blocks.is_empty() {
+                    md.push_str(&format!("**{label}:**\n\n"));
+                } else {
+                    md.push_str(&format!("**{label}:** {}\n", value_blocks[0].md.trim()));
+                    for b in &value_blocks[1..] {
+                        md.push('\n');
+                        md.push_str(b.md.trim());
+                        md.push('\n');
+                    }
+                    md.push('\n');
+                }
+                // Plain: fully flattened — label line then each value paragraph.
+                let label_plain = join_cell_blocks_plain(&row.cells[0]);
+                let label_plain = label_plain.trim_end_matches(':');
+                plain.push_str(label_plain);
+                plain.push('\n');
+                for b in value_cell
+                    .blocks
+                    .iter()
+                    .filter(|b| !b.plain.trim().is_empty())
+                {
+                    plain.push_str(b.plain.trim());
+                    plain.push('\n');
+                }
+                plain.push('\n');
+            }
+            DocxSegment::Grid(rows) => {
+                let (g_md, g_plain) = render_docx_grid(&rows, grid_width);
+                md.push_str(&g_md);
+                md.push('\n');
+                plain.push_str(&g_plain);
+                plain.push('\n');
+            }
+            DocxSegment::Fallback(row) => {
+                if docx_row_has_nested_table(row) {
+                    // The row carries a nested table: emit each block in place —
+                    // paragraphs as text, the nested table as a standalone block.
+                    for c in &row.cells {
+                        for b in &c.blocks {
+                            if b.md.trim().is_empty() {
+                                continue;
+                            }
+                            md.push_str(b.md.trim_end());
+                            md.push('\n');
+                            if !b.is_table {
+                                md.push('\n');
+                            }
+                            plain.push_str(b.plain.trim_end());
+                            plain.push('\n');
+                        }
+                    }
+                    md.push('\n');
+                    plain.push('\n');
+                } else {
+                    // Small standalone GFM table padded to the row's own cell count.
+                    let texts: Vec<String> = row.cells.iter().map(join_cell_blocks_md).collect();
+                    let refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+                    md.push_str(&build_table(&refs, &[]));
+                    md.push('\n');
+                    let texts_p: Vec<String> =
+                        row.cells.iter().map(join_cell_blocks_plain).collect();
+                    let refs_p: Vec<&str> = texts_p.iter().map(|s| s.as_str()).collect();
+                    plain.push_str(&build_table_plain(&refs_p, &[]));
+                    plain.push('\n');
+                }
+            }
+        }
+    }
+
+    (md, plain)
+}
+
+// ---- Table classification ----
+
+/// Authoritative grid width of a table.
+///
+/// Uses the `<w:tblGrid>`/`<w:gridCol>` count when present (decision: tblGrid is
+/// authoritative). Falls back to the maximum over rows of the summed `grid_span`
+/// when the grid is absent or unparsed.
+fn docx_grid_width(t: &DocxTable) -> usize {
+    if t.grid_width > 0 {
+        return t.grid_width;
+    }
+    t.rows
+        .iter()
+        .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Whether a row's cells exactly tile the full grid width.
+///
+/// True when the summed `grid_span` over all cells equals `grid_width`.
+/// Continuation cells of a vertical merge still occupy their columns, so their
+/// `grid_span` is counted like any other cell's.
+fn docx_row_tiles(row: &DocxRow, grid_width: usize) -> bool {
+    grid_width > 0 && row.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>() == grid_width
+}
+
+/// The layout role of a table row, used to drive hybrid rendering.
+#[derive(Debug, Clone, PartialEq)]
+enum DocxRowKind {
+    /// A single cell spanning the full grid width (e.g. a section header).
+    Banner,
+    /// A narrow label cell followed by a wide value cell spanning the rest.
+    LabelValue,
+    /// Cells that exactly tile the grid width — eligible to stay a GFM table.
+    Tiling,
+    /// Anything else (irregular partial-width rows).
+    Fallback,
+}
+
+/// Whether any cell in the row contains a nested-table block.
+///
+/// Such rows cannot be flattened into single grid cells, so they are linearized
+/// (classified `Fallback`) and their nested tables emitted as standalone blocks.
+fn docx_row_has_nested_table(row: &DocxRow) -> bool {
+    row.cells
+        .iter()
+        .any(|c| c.blocks.iter().any(|b| b.is_table))
+}
+
+/// Classify a single row by its cell layout. First matching rule wins.
+fn classify_docx_row(row: &DocxRow, grid_width: usize) -> DocxRowKind {
+    let cells = &row.cells;
+    // A row whose cell holds a nested table cannot become a grid cell; linearize.
+    if docx_row_has_nested_table(row) {
+        return DocxRowKind::Fallback;
+    }
+    // Banner: one cell covering the whole width.
+    if cells.len() == 1 && grid_width >= 1 && cells[0].grid_span.max(1) >= grid_width {
+        return DocxRowKind::Banner;
+    }
+    // Label/value: narrow label (1 column) + wide value cell that genuinely
+    // spans the remaining columns. The value must span at least 2 columns (so
+    // `grid_width >= 3`); in a 2-column grid a `[1, 1]` row is an ordinary data
+    // row, not a label/value pair.
+    if cells.len() == 2
+        && grid_width >= 3
+        && cells[0].grid_span.max(1) == 1
+        && cells[1].grid_span.max(1) == grid_width - 1
+    {
+        return DocxRowKind::LabelValue;
+    }
+    // Tiling: cells exactly fill the grid width.
+    if docx_row_tiles(row, grid_width) {
+        return DocxRowKind::Tiling;
+    }
+    DocxRowKind::Fallback
+}
+
+/// A contiguous run of rows sharing a layout role, ready to render as one block.
+#[derive(Debug)]
+enum DocxSegment<'a> {
+    /// A banner row → heading (if styled) or bold paragraph.
+    Banner(&'a DocxRow),
+    /// A label/value row → `**Label:** value`.
+    LabelValue(&'a DocxRow),
+    /// A maximal run of consecutive tiling rows → one GFM table (row 0 = header).
+    Grid(Vec<&'a DocxRow>),
+    /// An irregular row → its own small GFM table.
+    Fallback(&'a DocxRow),
+}
+
+/// Segment a table's rows into ordered render units.
+///
+/// Consecutive `Tiling` rows are coalesced into a single `Grid` segment; banner,
+/// label/value, and fallback rows are emitted as singletons in document order.
+/// Iterates an ordered slice only, so output ordering is deterministic.
+fn segment_docx_table<'a>(t: &'a DocxTable, grid_width: usize) -> Vec<DocxSegment<'a>> {
+    let mut segments: Vec<DocxSegment<'a>> = Vec::new();
+    let mut grid_run: Vec<&'a DocxRow> = Vec::new();
+
+    for row in &t.rows {
+        match classify_docx_row(row, grid_width) {
+            DocxRowKind::Tiling => grid_run.push(row),
+            kind => {
+                if !grid_run.is_empty() {
+                    segments.push(DocxSegment::Grid(std::mem::take(&mut grid_run)));
+                }
+                match kind {
+                    DocxRowKind::Banner => segments.push(DocxSegment::Banner(row)),
+                    DocxRowKind::LabelValue => segments.push(DocxSegment::LabelValue(row)),
+                    _ => segments.push(DocxSegment::Fallback(row)),
+                }
+            }
+        }
+    }
+    if !grid_run.is_empty() {
+        segments.push(DocxSegment::Grid(grid_run));
+    }
+    segments
+}
+
+/// Whether a table is "simple" and should use the plain GFM path unchanged.
+///
+/// True when no cell carries a horizontal or vertical merge and every row has the
+/// same cell count. Such tables render exactly as they did before hybrid handling,
+/// guaranteeing zero regression for ordinary data tables.
+fn docx_table_is_simple(t: &DocxTable) -> bool {
+    if t.rows.is_empty() {
+        return true;
+    }
+    // A nested table inside any cell forces the hybrid path so the inner table
+    // can be emitted as a standalone block rather than flattened into a cell.
+    if t.rows.iter().any(docx_row_has_nested_table) {
+        return false;
+    }
+    let width = t.rows[0].cells.len();
+    t.rows.iter().all(|r| {
+        r.cells.len() == width
+            && r.cells
+                .iter()
+                .all(|c| c.grid_span <= 1 && c.v_merge == VMerge::None)
+    })
+}
+
 /// Merge adjacent segments with the same formatting, then apply `wrap_formatting`
 /// once per merged group.
 fn merge_and_format_runs(runs: &[RunSegment]) -> String {
@@ -408,18 +879,9 @@ fn parse_document(
     // Track if last paragraph was a list item (for single-newline separation)
     let mut last_was_list = false;
 
-    // Table state
-    let mut in_table = false;
-    let mut in_table_row = false;
-    let mut in_table_cell = false;
-    let mut table_rows: Vec<Vec<String>> = Vec::new();
-    let mut current_row: Vec<String> = Vec::new();
-    let mut current_cell_text = String::new();
-    let mut cell_paragraph_count: usize = 0;
-    // Plain-text table state (no markdown formatting in cells)
-    let mut table_rows_plain: Vec<Vec<String>> = Vec::new();
-    let mut current_row_plain: Vec<String> = Vec::new();
-    let mut current_cell_text_plain = String::new();
+    // Table state: a stack of buffered tables supports nesting. The top frame
+    // is the table currently being parsed; an inner `<w:tbl>` pushes a new frame.
+    let mut table_stack: Vec<DocxTable> = Vec::new();
 
     // Drawing/Image state
     let mut in_drawing = false;
@@ -526,20 +988,19 @@ fn parse_document(
                         in_body = true;
                     }
                     "tbl" if in_body => {
-                        in_table = true;
-                        table_rows.clear();
-                        table_rows_plain.clear();
+                        // Push a new table frame (supports nested tables).
+                        table_stack.push(DocxTable::default());
                     }
-                    "tr" if in_table => {
-                        in_table_row = true;
-                        current_row.clear();
-                        current_row_plain.clear();
+                    "tr" if !table_stack.is_empty() => {
+                        let frame = table_stack.last_mut().unwrap();
+                        frame.in_row = true;
+                        frame.current_row = DocxRow::default();
                     }
-                    "tc" if in_table_row => {
-                        in_table_cell = true;
-                        current_cell_text.clear();
-                        current_cell_text_plain.clear();
-                        cell_paragraph_count = 0;
+                    "tc" if table_stack.last().is_some_and(|f| f.in_row) => {
+                        let frame = table_stack.last_mut().unwrap();
+                        frame.in_cell = true;
+                        frame.current_cell = DocxCell::default();
+                        frame.cell_paragraph_count = 0;
                     }
                     "p" if in_body => {
                         in_paragraph = true;
@@ -661,6 +1122,26 @@ fn parse_document(
                 let local_str = std::str::from_utf8(local.as_ref()).unwrap_or("");
 
                 match local_str {
+                    // `<w:gridCol>` inside `<w:tblGrid>` defines one grid column;
+                    // counting them yields the authoritative table width.
+                    "gridCol" if table_stack.last().is_some_and(|f| !f.in_row) => {
+                        table_stack.last_mut().unwrap().grid_width += 1;
+                    }
+                    // `<w:gridSpan w:val="N"/>` in `<w:tcPr>`: horizontal merge.
+                    "gridSpan" if table_stack.last().is_some_and(|f| f.in_cell) => {
+                        if let Some(n) = read_w_val(e).and_then(|v| v.parse::<usize>().ok()) {
+                            table_stack.last_mut().unwrap().current_cell.grid_span = n.max(1);
+                        }
+                    }
+                    // `<w:vMerge .../>` in `<w:tcPr>`: vertical merge. `w:val="restart"`
+                    // starts a merge; a bare `<w:vMerge/>` (or any other value) continues one.
+                    "vMerge" if table_stack.last().is_some_and(|f| f.in_cell) => {
+                        let v = match read_w_val(e).as_deref() {
+                            Some("restart") => VMerge::Restart,
+                            _ => VMerge::Continue,
+                        };
+                        table_stack.last_mut().unwrap().current_cell.v_merge = v;
+                    }
                     "pStyle" if in_para_properties => {
                         for attr in e.attributes().flatten() {
                             let local_name = attr.key.local_name();
@@ -824,48 +1305,42 @@ fn parse_document(
                     "body" => {
                         in_body = false;
                     }
-                    "tbl" if in_table => {
-                        // Render table
-                        if !table_rows.is_empty() {
-                            let first_row = &table_rows[0];
-                            let headers: Vec<&str> = first_row.iter().map(|s| s.as_str()).collect();
-                            let data_rows: Vec<Vec<&str>> = table_rows[1..]
-                                .iter()
-                                .map(|row| row.iter().map(|s| s.as_str()).collect())
-                                .collect();
-                            let table_md = build_table(&headers, &data_rows);
+                    "tbl" if !table_stack.is_empty() => {
+                        let table = table_stack.pop().unwrap();
+                        let (table_md, table_plain) = render_docx_table(&table);
+                        if table_stack.last().is_some_and(|f| f.in_cell) {
+                            // Nested table: attach its rendered output to the
+                            // enclosing cell as a block so it renders in place.
+                            if !table_md.is_empty() {
+                                table_stack.last_mut().unwrap().current_cell.blocks.push(
+                                    DocxCellBlock {
+                                        md: table_md,
+                                        plain: table_plain,
+                                        kind: ParagraphKind::Normal,
+                                        is_table: true,
+                                    },
+                                );
+                            }
+                        } else if !table_md.is_empty() {
+                            // Outermost table: write to the document output.
                             output.push_str(&table_md);
                             output.push('\n');
-                            // Use plain-text rows (no markdown formatting) for plain output
-                            let first_row_plain = &table_rows_plain[0];
-                            let headers_plain: Vec<&str> =
-                                first_row_plain.iter().map(|s| s.as_str()).collect();
-                            let data_rows_plain: Vec<Vec<&str>> = table_rows_plain[1..]
-                                .iter()
-                                .map(|row| row.iter().map(|s| s.as_str()).collect())
-                                .collect();
-                            let table_plain = build_table_plain(&headers_plain, &data_rows_plain);
                             plain_output.push_str(&table_plain);
                             plain_output.push('\n');
                         }
-                        in_table = false;
-                        table_rows.clear();
-                        table_rows_plain.clear();
                         last_was_list = false;
                     }
-                    "tr" if in_table_row => {
-                        table_rows.push(current_row.clone());
-                        current_row.clear();
-                        table_rows_plain.push(current_row_plain.clone());
-                        current_row_plain.clear();
-                        in_table_row = false;
+                    "tr" if table_stack.last().is_some_and(|f| f.in_row) => {
+                        let frame = table_stack.last_mut().unwrap();
+                        let row = std::mem::take(&mut frame.current_row);
+                        frame.rows.push(row);
+                        frame.in_row = false;
                     }
-                    "tc" if in_table_cell => {
-                        current_row.push(current_cell_text.trim().to_string());
-                        current_cell_text.clear();
-                        current_row_plain.push(current_cell_text_plain.trim().to_string());
-                        current_cell_text_plain.clear();
-                        in_table_cell = false;
+                    "tc" if table_stack.last().is_some_and(|f| f.in_cell) => {
+                        let frame = table_stack.last_mut().unwrap();
+                        let cell = std::mem::take(&mut frame.current_cell);
+                        frame.current_row.cells.push(cell);
+                        frame.in_cell = false;
                     }
                     "p" if in_paragraph => {
                         // Resolve list item kind from numPr
@@ -884,17 +1359,16 @@ fn parse_document(
                         // Plain text: no bold/italic markers, no link/image syntax
                         let current_para_text_plain = merge_runs_plain(&current_para_runs_plain);
 
-                        if in_table_cell {
-                            // In a table cell: accumulate text
-                            if cell_paragraph_count > 0 && !current_para_text.is_empty() {
-                                current_cell_text.push(' ');
-                            }
-                            current_cell_text.push_str(current_para_text.trim());
-                            if cell_paragraph_count > 0 && !current_para_text_plain.is_empty() {
-                                current_cell_text_plain.push(' ');
-                            }
-                            current_cell_text_plain.push_str(current_para_text_plain.trim());
-                            cell_paragraph_count += 1;
+                        if table_stack.last().is_some_and(|f| f.in_cell) {
+                            // In a table cell: buffer this paragraph as a content block.
+                            let frame = table_stack.last_mut().unwrap();
+                            frame.current_cell.blocks.push(DocxCellBlock {
+                                md: current_para_text.clone(),
+                                plain: current_para_text_plain.clone(),
+                                kind: current_para_kind.clone(),
+                                is_table: false,
+                            });
+                            frame.cell_paragraph_count += 1;
                         } else {
                             // Normal paragraph finalization
                             let is_list =
@@ -1039,6 +1513,18 @@ fn parse_document(
     };
 
     (markdown, plain_text, title, warnings, image_infos)
+}
+
+/// Read the `w:val` attribute of an element, if present (namespace-agnostic).
+fn read_w_val(e: &quick_xml::events::BytesStart) -> Option<String> {
+    for attr in e.attributes().flatten() {
+        let local_name = attr.key.local_name();
+        let k = std::str::from_utf8(local_name.as_ref()).unwrap_or("");
+        if k == "val" {
+            return Some(String::from_utf8_lossy(&attr.value).to_string());
+        }
+    }
+    None
 }
 
 /// Check if a `w:val` attribute on an element is explicitly false ("0" or "false").
@@ -2380,11 +2866,10 @@ mod tests {
     }
 
     #[test]
-    fn test_docx_table_merged_cells_no_panic() {
-        // Table with gridSpan (horizontal merge) — converter doesn't handle merging
-        // but should not panic. The first row has 1 cell with gridSpan=2, so
-        // build_table treats it as a 1-column table (header dictates column count).
-        // Row 2's second cell "B" gets truncated — that's expected current behavior.
+    fn test_docx_table_gridspan_banner_preserves_all_columns() {
+        // A full-width gridSpan banner over a two-column data row. The banner must
+        // not collapse the table to one column: both "A" and "B" must survive.
+        // (This previously truncated every row to its first cell.)
         let body = r#"<w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>Merged</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
         let doc = wrap_body(body);
         let data = build_test_docx(&doc, None, None);
@@ -2392,9 +2877,503 @@ mod tests {
         let result = converter
             .convert(&data, &ConversionOptions::default())
             .unwrap();
-        // No panic, and at least the merged header + first cell are preserved
-        assert!(result.markdown.contains("Merged"));
-        assert!(result.markdown.contains("A"));
+        // The banner row linearizes to a bold paragraph (not a one-column table).
+        assert!(
+            result.markdown.contains("**Merged**"),
+            "banner missing: {}",
+            result.markdown
+        );
+        // The data row keeps both columns.
+        assert!(
+            result.markdown.contains("| A | B |"),
+            "columns truncated: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_docx_table_depth_stack_nested_smoke() {
+        // A table nested inside a cell of an outer table. The parser tracks table
+        // depth via a stack, so both the outer cell text and the inner table's
+        // cells must survive (the old single-flag machine could not nest).
+        let body = r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>outer</w:t></w:r></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl>"#;
+        let doc = wrap_body(body);
+        let data = build_test_docx(&doc, None, None);
+        let converter = DocxConverter;
+        let result = converter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        assert!(
+            result.markdown.contains("outer"),
+            "outer cell text missing: {}",
+            result.markdown
+        );
+        assert!(
+            result.markdown.contains("inner"),
+            "inner table text missing: {}",
+            result.markdown
+        );
+    }
+
+    // ---- Table classifier unit tests ----
+
+    /// Build a cell with the given markdown text, grid span, and merge state.
+    fn cell(text: &str, grid_span: usize, v_merge: VMerge) -> DocxCell {
+        DocxCell {
+            grid_span,
+            v_merge,
+            blocks: vec![DocxCellBlock {
+                md: text.to_string(),
+                plain: text.to_string(),
+                kind: ParagraphKind::Normal,
+                is_table: false,
+            }],
+        }
+    }
+
+    /// Build a row from cells.
+    fn row(cells: Vec<DocxCell>) -> DocxRow {
+        DocxRow { cells }
+    }
+
+    #[test]
+    fn test_docx_grid_width_from_gridcol() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![cell("a", 1, VMerge::None)])],
+            ..Default::default()
+        };
+        assert_eq!(docx_grid_width(&t), 3);
+    }
+
+    #[test]
+    fn test_docx_grid_width_fallback_max_span() {
+        let t = DocxTable {
+            grid_width: 0,
+            rows: vec![
+                row(vec![cell("a", 2, VMerge::None)]),
+                row(vec![
+                    cell("a", 1, VMerge::None),
+                    cell("b", 1, VMerge::None),
+                    cell("c", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(docx_grid_width(&t), 3);
+    }
+
+    #[test]
+    fn test_docx_row_tiles_exact() {
+        let r = row(vec![
+            cell("a", 1, VMerge::None),
+            cell("b", 1, VMerge::None),
+            cell("c", 1, VMerge::None),
+        ]);
+        assert!(docx_row_tiles(&r, 3));
+    }
+
+    #[test]
+    fn test_docx_row_tiles_banner_full_width() {
+        // A single full-width cell technically tiles; banner classification (which
+        // is checked before tiling) is what distinguishes it.
+        let r = row(vec![cell("a", 3, VMerge::None)]);
+        assert!(docx_row_tiles(&r, 3));
+    }
+
+    #[test]
+    fn test_docx_row_tiles_short_false() {
+        let r = row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]);
+        assert!(!docx_row_tiles(&r, 3));
+    }
+
+    #[test]
+    fn test_classify_docx_row_banner() {
+        let r = row(vec![cell("Section", 5, VMerge::None)]);
+        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::Banner);
+    }
+
+    #[test]
+    fn test_classify_docx_row_label_value() {
+        let r = row(vec![
+            cell("Label", 1, VMerge::None),
+            cell("Value", 4, VMerge::None),
+        ]);
+        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::LabelValue);
+    }
+
+    #[test]
+    fn test_classify_docx_row_tiling() {
+        let r = row(vec![
+            cell("a", 1, VMerge::None),
+            cell("b", 1, VMerge::None),
+            cell("c", 1, VMerge::None),
+        ]);
+        assert_eq!(classify_docx_row(&r, 3), DocxRowKind::Tiling);
+    }
+
+    #[test]
+    fn test_classify_docx_row_fallback() {
+        // Two narrow cells in a 5-column grid: neither banner, label/value, nor tiling.
+        let r = row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]);
+        assert_eq!(classify_docx_row(&r, 5), DocxRowKind::Fallback);
+    }
+
+    #[test]
+    fn test_segment_docx_banner_then_grid() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![cell("Banner", 3, VMerge::None)]),
+                row(vec![
+                    cell("a", 1, VMerge::None),
+                    cell("b", 1, VMerge::None),
+                    cell("c", 1, VMerge::None),
+                ]),
+                row(vec![
+                    cell("d", 1, VMerge::None),
+                    cell("e", 1, VMerge::None),
+                    cell("f", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let segs = segment_docx_table(&t, 3);
+        assert_eq!(segs.len(), 2);
+        assert!(matches!(segs[0], DocxSegment::Banner(_)));
+        match &segs[1] {
+            DocxSegment::Grid(rows) => assert_eq!(rows.len(), 2),
+            other => panic!("expected Grid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_segment_docx_grid_split_by_labelvalue() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![
+                    cell("a", 1, VMerge::None),
+                    cell("b", 1, VMerge::None),
+                    cell("c", 1, VMerge::None),
+                ]),
+                row(vec![cell("L", 1, VMerge::None), cell("V", 2, VMerge::None)]),
+                row(vec![
+                    cell("d", 1, VMerge::None),
+                    cell("e", 1, VMerge::None),
+                    cell("f", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let segs = segment_docx_table(&t, 3);
+        assert_eq!(segs.len(), 3);
+        assert!(matches!(segs[0], DocxSegment::Grid(_)));
+        assert!(matches!(segs[1], DocxSegment::LabelValue(_)));
+        assert!(matches!(segs[2], DocxSegment::Grid(_)));
+    }
+
+    #[test]
+    fn test_docx_table_is_simple_true() {
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
+                row(vec![cell("c", 1, VMerge::None), cell("d", 1, VMerge::None)]),
+            ],
+            ..Default::default()
+        };
+        assert!(docx_table_is_simple(&t));
+    }
+
+    #[test]
+    fn test_docx_table_is_simple_false_gridspan() {
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![row(vec![cell("a", 2, VMerge::None)])],
+            ..Default::default()
+        };
+        assert!(!docx_table_is_simple(&t));
+    }
+
+    #[test]
+    fn test_docx_table_is_simple_false_vmerge() {
+        let t = DocxTable {
+            grid_width: 1,
+            rows: vec![row(vec![cell("a", 1, VMerge::Restart)])],
+            ..Default::default()
+        };
+        assert!(!docx_table_is_simple(&t));
+    }
+
+    #[test]
+    fn test_docx_table_is_simple_false_ragged() {
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![cell("a", 1, VMerge::None), cell("b", 1, VMerge::None)]),
+                row(vec![cell("c", 1, VMerge::None)]),
+            ],
+            ..Default::default()
+        };
+        assert!(!docx_table_is_simple(&t));
+    }
+
+    // ---- Hybrid render unit tests ----
+
+    /// Build a cell whose first paragraph carries the given kind (for banner tests).
+    fn cell_kind(text: &str, grid_span: usize, kind: ParagraphKind) -> DocxCell {
+        DocxCell {
+            grid_span,
+            v_merge: VMerge::None,
+            blocks: vec![DocxCellBlock {
+                md: text.to_string(),
+                plain: text.to_string(),
+                kind,
+                is_table: false,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_docx_expand_row_to_grid_hspan() {
+        let r = row(vec![cell("X", 2, VMerge::None), cell("Y", 1, VMerge::None)]);
+        assert_eq!(expand_row_to_grid(&r, 3, false), vec!["X", "", "Y"]);
+    }
+
+    #[test]
+    fn test_docx_expand_row_vmerge_continue_empty() {
+        let r = row(vec![cell("kept", 1, VMerge::Continue)]);
+        assert_eq!(expand_row_to_grid(&r, 1, false), vec![""]);
+    }
+
+    #[test]
+    fn test_docx_render_banner_bold() {
+        // Banner with a Normal paragraph → bold paragraph, not a heading.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![cell("Section Header", 3, VMerge::None)])],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("**Section Header**"), "md: {md}");
+        assert!(!md.contains("# Section Header"), "md: {md}");
+        assert!(!md.contains('|'), "banner must not be a table: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_banner_heading() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![cell_kind(
+                "Section Header",
+                3,
+                ParagraphKind::Heading(2),
+            )])],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("## Section Header"), "md: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_label_value() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![
+                cell("Date", 1, VMerge::None),
+                cell("Monday", 2, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("**Date:** Monday"), "md: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_label_value_existing_colon_not_doubled() {
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![row(vec![
+                cell("Date:", 1, VMerge::None),
+                cell("Monday", 2, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("**Date:** Monday"), "md: {md}");
+        assert!(!md.contains("Date::"), "colon doubled: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_grid_region_full_width() {
+        // A banner over a 3-column data grid: the grid keeps all columns.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![cell("Banner", 3, VMerge::None)]),
+                row(vec![
+                    cell("A", 1, VMerge::None),
+                    cell("B", 1, VMerge::None),
+                    cell("C", 1, VMerge::None),
+                ]),
+                row(vec![
+                    cell("1", 1, VMerge::None),
+                    cell("2", 1, VMerge::None),
+                    cell("3", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("| A | B | C |"), "md: {md}");
+        assert!(md.contains("| 1 | 2 | 3 |"), "md: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_grid_vmerge_continue_blank() {
+        // vMerge restart label + continuation: continuation cell renders empty.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![
+                    cell("Label", 1, VMerge::Restart),
+                    cell("Head", 1, VMerge::None),
+                ]),
+                row(vec![
+                    cell("", 1, VMerge::Continue),
+                    cell("Val", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("| Label | Head |"), "md: {md}");
+        // The continuation cell is empty in the data row.
+        assert!(md.contains("|  | Val |"), "md: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_pipe_in_cell_escaped() {
+        // A literal pipe inside a hybrid-grid cell must be escaped by build_table.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![cell("Banner", 2, VMerge::None)]),
+                row(vec![
+                    cell("a|b", 1, VMerge::None),
+                    cell("c", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t);
+        assert!(md.contains("a\\|b"), "pipe not escaped: {md}");
+    }
+
+    #[test]
+    fn test_docx_plain_linearized_flattened() {
+        // Plain text: banner + label/value linearize with NO markers; grid region
+        // stays tab-separated.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![cell("Section", 3, VMerge::None)]),
+                row(vec![
+                    cell("Field", 1, VMerge::None),
+                    cell("Value", 2, VMerge::None),
+                ]),
+                row(vec![
+                    cell("A", 1, VMerge::None),
+                    cell("B", 1, VMerge::None),
+                    cell("C", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let (_md, plain) = render_docx_table(&t);
+        assert!(plain.contains("Section"), "plain: {plain}");
+        assert!(plain.contains("Field"), "plain: {plain}");
+        assert!(plain.contains("Value"), "plain: {plain}");
+        // No markdown markers in linearized plain text.
+        assert!(!plain.contains("**"), "plain has bold markers: {plain}");
+        assert!(!plain.contains("**Field:**"), "plain: {plain}");
+        // Grid region is tab-separated.
+        assert!(plain.contains("A\tB\tC"), "plain grid not tabbed: {plain}");
+    }
+
+    #[test]
+    fn test_docx_render_deterministic() {
+        // Byte-stable output: two renders of the same table must be identical.
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![cell("Banner", 3, VMerge::None)]),
+                row(vec![
+                    cell("Field", 1, VMerge::None),
+                    cell("Value", 2, VMerge::None),
+                ]),
+                row(vec![
+                    cell("A", 1, VMerge::None),
+                    cell("B", 1, VMerge::None),
+                    cell("C", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(render_docx_table(&t), render_docx_table(&t));
+    }
+
+    #[test]
+    fn test_docx_nested_table_rendered_fully() {
+        // A 2x2 inner table inside a single outer cell. All four inner cells must
+        // appear, rendered as a GFM table nested within the outer cell's position.
+        let inner = r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>i1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>i2</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>i3</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>i4</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
+        let body = format!(
+            r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>outer-text</w:t></w:r></w:p>{inner}</w:tc></w:tr></w:tbl>"#
+        );
+        let doc = wrap_body(&body);
+        let data = build_test_docx(&doc, None, None);
+        let result = DocxConverter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        for needle in ["outer-text", "i1", "i2", "i3", "i4"] {
+            assert!(
+                result.markdown.contains(needle),
+                "missing {needle}: {}",
+                result.markdown
+            );
+        }
+        // The inner table is rendered as a GFM table (has a separator row).
+        assert!(
+            result.markdown.contains("| i1 | i2 |"),
+            "{}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_docx_nested_table_forces_linearize() {
+        // The outer row holds a nested table, so it must linearize: the outer
+        // cell text is not crammed into a one-column GFM cell with <br> noise.
+        let inner =
+            r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
+        let body = format!(
+            r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>before</w:t></w:r></w:p>{inner}</w:tc></w:tr></w:tbl>"#
+        );
+        let doc = wrap_body(&body);
+        let data = build_test_docx(&doc, None, None);
+        let result = DocxConverter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        assert!(result.markdown.contains("before"), "{}", result.markdown);
+        assert!(result.markdown.contains("inner"), "{}", result.markdown);
+        // No <br>-joined cramming of the outer paragraph with the inner table.
+        assert!(
+            !result.markdown.contains("before<br>"),
+            "outer cell was crammed: {}",
+            result.markdown
+        );
     }
 
     // ---- List tests ----

--- a/src/converter/docx.rs
+++ b/src/converter/docx.rs
@@ -436,8 +436,11 @@ fn join_cell_blocks_plain(cell: &DocxCell) -> String {
 /// A cell with `grid_span = k` places its (joined) text in the first of its `k`
 /// columns and leaves the other `k - 1` empty (empty-fill). Vertical-merge
 /// continuation cells render empty. The `plain` flag selects the plain-text
-/// join. The result always has exactly `grid_width` entries (truncated/padded if
-/// the row's spans do not sum to the width).
+/// join. The result always has exactly `grid_width` entries. Because
+/// `docx_grid_width` treats `tblGrid` as a floor (it is at least the widest row),
+/// the trailing `resize` only ever PADS short rows — it never truncates a real
+/// cell. The per-cell span clamp remains only as defense against a single
+/// malformed span on a non-widest row.
 fn expand_row_to_grid(row: &DocxRow, grid_width: usize, plain: bool) -> Vec<String> {
     let mut cols: Vec<String> = Vec::with_capacity(grid_width);
     for c in &row.cells {
@@ -509,9 +512,14 @@ fn render_docx_grid(rows: &[&DocxRow], grid_width: usize) -> (String, String) {
 /// downstream (LLM) consumers.
 ///
 /// The one exception is a table that contains a nested table: a nested table
-/// cannot live inside a single GFM cell, so such a table is linearized — each
-/// cell's paragraphs and any nested table are emitted as standalone blocks.
-fn render_docx_table(table: &DocxTable) -> (String, String) {
+/// cannot live inside a single GFM cell, so the whole table is linearized — each
+/// cell's paragraphs and any nested table are emitted as standalone blocks. This
+/// is per-table (not per-row) by deliberate maintainer decision: consistency over
+/// prettiness. Only bugs within that path are fixed; the linearization is kept.
+///
+/// `warnings` collects a [`WarningCode::ResourceLimitReached`] entry if the table
+/// is so large that rows are dropped to honor `MAX_TABLE_CELLS`.
+fn render_docx_table(table: &DocxTable, warnings: &mut Vec<ConversionWarning>) -> (String, String) {
     if table.rows.is_empty() {
         return (String::new(), String::new());
     }
@@ -521,59 +529,112 @@ fn render_docx_table(table: &DocxTable) -> (String, String) {
         return (String::new(), String::new());
     }
 
-    // Common case: no nested tables → one empty-filled GFM grid.
+    // Common case: no nested tables → one empty-filled GFM grid. Bound the
+    // rendered area (rows × grid_width) at MAX_TABLE_CELLS: every cell is escaped
+    // and emitted, so an extreme grid would otherwise produce gigabytes of
+    // markdown. Excess rows are dropped — and, because dropping content must be
+    // observable, a ResourceLimitReached warning is appended.
     if !table.rows.iter().any(docx_row_has_nested_table) {
-        let rows: Vec<&DocxRow> = table.rows.iter().collect();
+        let max_rows = (MAX_TABLE_CELLS / grid_width).max(1);
+        if table.rows.len() > max_rows {
+            warnings.push(ConversionWarning {
+                code: WarningCode::ResourceLimitReached,
+                message: format!(
+                    "table truncated to {max_rows} rows (limit {MAX_TABLE_CELLS} cells)"
+                ),
+                location: None,
+            });
+        }
+        let rows: Vec<&DocxRow> = table.rows.iter().take(max_rows).collect();
         return render_docx_grid(&rows, grid_width);
     }
 
     // A nested table cannot be a grid cell: linearize the whole table, emitting
     // each cell's paragraphs and nested tables as standalone blocks in order.
+    // Linearization is per-table (whole table), not per-row, by deliberate
+    // maintainer decision (consistency over prettiness); only the bugs below are
+    // fixed within this path.
+    //
+    // Within the table, blocks are separated by one blank line in the markdown
+    // stream and one newline in the plain stream so adjacent paragraphs/tables do
+    // not fuse. A block is skipped when it has no meaningful content in EITHER
+    // stream (both md and plain trim empty), so a block with non-empty md but
+    // empty plain (e.g. an empty nested table) cannot inject a phantom blank line
+    // into plain or a degenerate empty GFM table into md.
     let mut md = String::new();
     let mut plain = String::new();
     for row in &table.rows {
         for c in &row.cells {
             for b in &c.blocks {
-                if b.md.trim().is_empty() {
+                let md_block = b.md.trim_end();
+                let plain_block = b.plain.trim_end();
+                // Skip unless the block carries content in at least one stream.
+                if md_block.trim_start().is_empty() && plain_block.trim_start().is_empty() {
                     continue;
                 }
-                md.push_str(b.md.trim_end());
-                md.push_str("\n\n");
-                plain.push_str(b.plain.trim_end());
-                plain.push('\n');
+                // Never emit a nested table whose rendered markdown is empty:
+                // it would otherwise contribute a degenerate empty GFM table.
+                if !(b.is_table && md_block.is_empty()) {
+                    md.push_str(md_block);
+                    md.push_str("\n\n");
+                }
+                if !(b.is_table && plain_block.is_empty()) {
+                    plain.push_str(plain_block);
+                    plain.push('\n');
+                }
             }
         }
     }
-    plain.push('\n');
+
+    // Normalize each stream to end in exactly one newline, matching the contract
+    // of `build_table`/`build_table_plain` on the normal-grid path: the per-block
+    // `"\n\n"` terminator leaves a trailing blank line on the last block, but the
+    // outer caller appends one more `\n` after the table. Trimming to a single
+    // trailing newline here means the caller's `\n` yields exactly one blank line
+    // before the following block — identical to a normal table (no extra blank
+    // line, the FINDING #11 regression).
+    let md = trim_to_single_trailing_newline(&md);
+    let plain = trim_to_single_trailing_newline(&plain);
 
     (md, plain)
+}
+
+/// Trim trailing whitespace and, if any content remains, re-append exactly one
+/// `\n`. An all-empty string stays empty. Matches the trailing-newline contract
+/// of the normal-grid table builders so callers can append a single `\n`
+/// uniformly regardless of which render path produced the table.
+fn trim_to_single_trailing_newline(s: &str) -> String {
+    let trimmed = s.trim_end();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        format!("{trimmed}\n")
+    }
 }
 
 // ---- Table classification ----
 
 /// Authoritative grid width of a table.
 ///
-/// Uses the `<w:tblGrid>`/`<w:gridCol>` count when present (decision: tblGrid is
-/// authoritative). Falls back to the maximum over rows of the summed `grid_span`
-/// when the grid is absent or unparsed.
+/// The `<w:tblGrid>`/`<w:gridCol>` count is a FLOOR, not a ceiling: a row whose
+/// cells (by summed `grid_span`) are wider than the declared grid still keeps
+/// every cell. The width is therefore the maximum of the `tblGrid` count and the
+/// widest row, so `expand_row_to_grid` only ever pads — never truncates — a real
+/// cell. (Word occasionally emits a `tblGrid` narrower than an actual row; taking
+/// the ceiling there silently dropped trailing cells.) The grid is still bounded
+/// by `MAX_TABLE_COLS` so an extreme span/gridCol count cannot drive unbounded
+/// column allocation downstream.
 fn docx_grid_width(t: &DocxTable) -> usize {
-    let width = if t.grid_width > 0 {
-        t.grid_width
-    } else {
-        t.rows
-            .iter()
-            .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
-            .max()
-            .unwrap_or(0)
-    };
-    // Bound the rendered grid width so an extreme span/gridCol count cannot drive
-    // unbounded column allocation downstream.
+    let widest_row = t
+        .rows
+        .iter()
+        .map(|r| r.cells.iter().map(|c| c.grid_span.max(1)).sum::<usize>())
+        .max()
+        .unwrap_or(0);
+    let width = t.grid_width.max(widest_row);
     width.min(MAX_TABLE_COLS)
 }
 
-/// Whether a row's cells exactly tile the full grid width.
-///
-/// True when the summed `grid_span` over all cells equals `grid_width`.
 /// Whether any cell in the row contains a nested-table block.
 ///
 /// A nested table cannot live inside a single GFM cell, so a table containing one
@@ -583,6 +644,23 @@ fn docx_row_has_nested_table(row: &DocxRow) -> bool {
     row.cells
         .iter()
         .any(|c| c.blocks.iter().any(|b| b.is_table))
+}
+
+/// Whether a buffered table has any content worth rendering.
+///
+/// A table with no cells, or whose every cell block is blank in both the markdown
+/// and plain streams, renders only to an empty/skeleton GFM table (e.g.
+/// `|  |\n|---|`). Such a table is suppressed entirely when it appears nested
+/// inside a cell, so it contributes no degenerate phantom table or stray blank
+/// line to the enclosing output.
+fn docx_table_has_content(t: &DocxTable) -> bool {
+    t.rows.iter().any(|r| {
+        r.cells.iter().any(|c| {
+            c.blocks
+                .iter()
+                .any(|b| !b.md.trim().is_empty() || !b.plain.trim().is_empty())
+        })
+    })
 }
 
 /// Merge adjacent segments with the same formatting, then apply `wrap_formatting`
@@ -1116,11 +1194,16 @@ fn parse_document(
                     }
                     "tbl" if !table_stack.is_empty() => {
                         let table = table_stack.pop().unwrap();
-                        let (table_md, table_plain) = render_docx_table(&table);
+                        // A content-empty nested/inner table would render only to a
+                        // degenerate skeleton (e.g. `|  |\n|---|`); skip it entirely
+                        // so it never injects a phantom table into markdown or a
+                        // stray blank line into plain text.
+                        let has_content = docx_table_has_content(&table);
+                        let (table_md, table_plain) = render_docx_table(&table, &mut warnings);
                         if table_stack.last().is_some_and(|f| f.in_cell) {
                             // Nested table: attach its rendered output to the
                             // enclosing cell as a block so it renders in place.
-                            if !table_md.is_empty() {
+                            if has_content && !table_md.is_empty() {
                                 table_stack.last_mut().unwrap().current_cell.blocks.push(
                                     DocxCellBlock {
                                         md: table_md,
@@ -1129,7 +1212,7 @@ fn parse_document(
                                     },
                                 );
                             }
-                        } else if !table_md.is_empty() {
+                        } else if has_content && !table_md.is_empty() {
                             // Outermost table: write to the document output.
                             output.push_str(&table_md);
                             output.push('\n');
@@ -1327,6 +1410,14 @@ fn parse_document(
 /// value cannot drive unbounded allocation when a row is expanded to the grid
 /// width. Far larger than any real table.
 const MAX_TABLE_COLS: usize = 4096;
+
+/// Upper bound on the number of rendered table cells (rows × grid width).
+///
+/// `MAX_TABLE_COLS` bounds the width, but the row count is otherwise unbounded:
+/// a hostile document with millions of `<w:tr>` rows would materialize and escape
+/// a grid of arbitrary size. This caps the product so worst-case output stays a
+/// few MB. Mirrors the HTML converter's value. Far larger than any real table.
+const MAX_TABLE_CELLS: usize = 100_000;
 
 /// Parse a `<w:tblGrid>`/`<w:tcPr>` child element (`gridCol`, `gridSpan`,
 /// `vMerge`) into the current table frame.
@@ -2819,6 +2910,84 @@ mod tests {
         assert_eq!(docx_grid_width(&t), 3);
     }
 
+    #[test]
+    fn test_docx_grid_width_tblgrid_is_floor_not_ceiling() {
+        // tblGrid declares 2 columns but a row actually has 3 single-span cells.
+        // The grid width must widen to 3 so no cell is dropped.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![row(vec![
+                cell("A", 1, VMerge::None),
+                cell("B", 1, VMerge::None),
+                cell("C", 1, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        assert_eq!(docx_grid_width(&t), 3);
+    }
+
+    #[test]
+    fn test_docx_grid_width_uniform_match_unchanged() {
+        // When tblGrid equals the widest row, the width is byte-identical (the
+        // floor change must not perturb ordinary uniform tables).
+        let t = DocxTable {
+            grid_width: 3,
+            rows: vec![
+                row(vec![
+                    cell("a", 1, VMerge::None),
+                    cell("b", 1, VMerge::None),
+                    cell("c", 1, VMerge::None),
+                ]),
+                row(vec![
+                    cell("d", 1, VMerge::None),
+                    cell("e", 1, VMerge::None),
+                    cell("f", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(docx_grid_width(&t), 3);
+    }
+
+    #[test]
+    fn test_docx_render_three_cells_in_two_col_grid_keeps_all() {
+        // 3 single-span cells A,B,C in a 2-col tblGrid: all three survive.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![
+                row(vec![
+                    cell("H1", 1, VMerge::None),
+                    cell("H2", 1, VMerge::None),
+                ]),
+                row(vec![
+                    cell("A", 1, VMerge::None),
+                    cell("B", 1, VMerge::None),
+                    cell("C", 1, VMerge::None),
+                ]),
+            ],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
+        assert!(md.contains("| A | B | C |"), "trailing cell dropped: {md}");
+    }
+
+    #[test]
+    fn test_docx_render_gridspan_overflow_keeps_trailing_cell() {
+        // A [gridSpan=2 X, Y] row in a 2-col grid sums to 3 > grid_width: Y must
+        // not be truncated. Grid widens to 3; X empty-fills its second column.
+        let t = DocxTable {
+            grid_width: 2,
+            rows: vec![row(vec![
+                cell("X", 2, VMerge::None),
+                cell("Y", 1, VMerge::None),
+            ])],
+            ..Default::default()
+        };
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
+        // Single row => header only; X spans cols 1-2 (empty-filled), Y in col 3.
+        assert!(md.contains("| X |  | Y |"), "Y truncated: {md}");
+    }
+
     // ---- Grid render unit tests ----
 
     #[test]
@@ -2863,7 +3032,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let (md, _plain) = render_docx_table(&t);
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
         // One GFM table: the banner is the header row, empty-filled.
         assert!(md.contains("| Section Header |  |  |"), "md: {md}");
         assert!(md.contains("| A | B | C |"), "md: {md}");
@@ -2884,7 +3053,7 @@ mod tests {
             ])],
             ..Default::default()
         };
-        let (md, _plain) = render_docx_table(&t);
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
         assert!(md.contains("| Date | Monday |  |"), "md: {md}");
         assert!(!md.contains("**Date:**"), "md: {md}");
     }
@@ -2908,7 +3077,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let (md, _plain) = render_docx_table(&t);
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
         assert!(md.contains("| A | B | C |"), "md: {md}");
         assert!(md.contains("| x | spans |  |"), "md: {md}");
     }
@@ -2930,7 +3099,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let (md, _plain) = render_docx_table(&t);
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
         assert!(md.contains("| Label | Head |"), "md: {md}");
         // The continuation cell is empty in the data row.
         assert!(md.contains("|  | Val |"), "md: {md}");
@@ -2953,7 +3122,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let (md, _plain) = render_docx_table(&t);
+        let (md, _plain) = render_docx_table(&t, &mut Vec::new());
         assert!(md.contains("a\\|b"), "pipe not escaped: {md}");
     }
 
@@ -2972,7 +3141,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        let (_md, plain) = render_docx_table(&t);
+        let (_md, plain) = render_docx_table(&t, &mut Vec::new());
         assert!(plain.contains("Section"), "plain: {plain}");
         assert!(!plain.contains("**"), "plain has markers: {plain}");
         assert!(plain.contains("A\tB\tC"), "plain not tabbed: {plain}");
@@ -2997,7 +3166,10 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert_eq!(render_docx_table(&t), render_docx_table(&t));
+        assert_eq!(
+            render_docx_table(&t, &mut Vec::new()),
+            render_docx_table(&t, &mut Vec::new())
+        );
     }
 
     #[test]
@@ -3063,6 +3235,89 @@ mod tests {
             !result.markdown.contains("before<br>"),
             "outer cell was crammed: {}",
             result.markdown
+        );
+    }
+
+    #[test]
+    fn test_docx_empty_nested_table_no_phantom_table_end_to_end() {
+        // An outer cell holds real text followed by a nested table whose only cell
+        // is empty. Driven through the REAL parser (not a hand-built block): the
+        // empty inner table renders to a degenerate skeleton (`|  |\n|---|`) and is
+        // suppressed entirely. With the empty nested table gone, the outer 1x1
+        // table is a clean grid `| OuterText |`; crucially there is NO second,
+        // phantom empty table and the markdown/plain streams agree on the content.
+        let body = r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>OuterText</w:t></w:r></w:p><w:tbl><w:tr><w:tc><w:p/></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl>"#;
+        let doc = wrap_body(body);
+        let data = build_test_docx(&doc, None, None);
+        let result = DocxConverter
+            .convert(&data, &ConversionOptions::default())
+            .unwrap();
+        assert!(
+            result.markdown.contains("OuterText"),
+            "md: {:?}",
+            result.markdown
+        );
+        // The empty inner table contributed no skeleton: a single separator row
+        // (the outer table's own), and no empty `|  |` data cell from the inner one.
+        assert_eq!(
+            result.markdown.matches("---").count(),
+            1,
+            "phantom nested separator in md: {:?}",
+            result.markdown
+        );
+        assert!(
+            !result.markdown.contains("|  |"),
+            "phantom empty nested cell in md: {:?}",
+            result.markdown
+        );
+        // plain_text agrees on the content (the inner empty table left no residue).
+        assert!(
+            result.plain_text.contains("OuterText"),
+            "plain: {:?}",
+            result.plain_text
+        );
+        assert_eq!(
+            result.markdown.matches("OuterText").count(),
+            1,
+            "md: {:?}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_docx_linearize_skips_block_empty_in_both_streams() {
+        // A block empty in BOTH md and plain is skipped entirely; a sibling
+        // nested-table block keeps the table on the linearize path.
+        let t = DocxTable {
+            grid_width: 1,
+            rows: vec![row(vec![DocxCell {
+                grid_span: 1,
+                v_merge: VMerge::None,
+                blocks: vec![
+                    DocxCellBlock {
+                        md: "   ".to_string(),
+                        plain: "   ".to_string(),
+                        is_table: false,
+                    },
+                    DocxCellBlock {
+                        md: "| i |\n|---|\n| i |\n".to_string(),
+                        plain: "i\n".to_string(),
+                        is_table: true,
+                    },
+                ],
+            }])],
+            ..Default::default()
+        };
+        let (md, plain) = render_docx_table(&t, &mut Vec::new());
+        // Only the nested table content is present; the blank block contributed
+        // nothing to either stream.
+        assert!(
+            md.starts_with("| i |"),
+            "leading blank block leaked: {md:?}"
+        );
+        assert!(
+            plain.starts_with("i\n"),
+            "leading blank block leaked: {plain:?}"
         );
     }
 

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -32,10 +32,11 @@ const MAX_TABLE_ROWS: usize = 4096;
 /// emitting once the running total of output cells reaches this value
 /// (best-effort truncation, matching the silent style of the per-cell clamps).
 ///
-/// 1_000_000 is far larger than any real-world table (a 1000x1000 grid) yet
-/// keeps peak `HtmlCell` allocation to the low hundreds of MB worst case, which
-/// is acceptable for a best-effort converter.
-const MAX_TABLE_CELLS: usize = 1_000_000;
+/// Every table renders as a single GFM grid, so all materialized cells are also
+/// escaped and joined into the output. 100_000 is far larger than any real-world
+/// table (e.g. 200x500) yet keeps both peak `HtmlCell` allocation and the
+/// rendered table size bounded to a few MB worst case.
+const MAX_TABLE_CELLS: usize = 100_000;
 
 /// Converts HTML files to Markdown.
 pub struct HtmlConverter;
@@ -129,10 +130,6 @@ struct HtmlCell {
     colspan: usize,
     /// Rows this cell spans (`rowspan`), always at least 1.
     rowspan: usize,
-    /// True when the cell contains a heading element (`<h1>`..`<h6>`).
-    has_heading: bool,
-    /// Heading level of the first contained heading, if any (for banner promotion).
-    heading_level: u8,
     /// Accumulated cell text.
     content: String,
     /// Rendered markdown of a nested table inside this cell, if any. Kept
@@ -334,23 +331,16 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 _ if state.skip_depth > 0 => {}
                 "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
                     let level = tag[1..].parse::<u8>().unwrap_or(1);
-                    // A heading inside a table cell is recorded on the cell so a
-                    // banner row can be promoted to that heading level; the cell's
-                    // text is still accumulated normally (no heading markers).
+                    // A heading inside a table cell keeps its text inline in the
+                    // cell (no heading markers), but headings are block elements, so
+                    // separate their text from any preceding cell content so two
+                    // headings in one cell do not mash together (e.g. "FirstSecond").
                     if let Some(tc) = state.table_stack.last_mut()
                         && tc.in_cell
                     {
-                        // Headings are block elements: separate their text from any
-                        // preceding cell content so multiple headings in one cell do
-                        // not mash together (e.g. "FirstSecond").
                         let cur = &mut tc.current_cell.content;
                         if !cur.is_empty() && !cur.ends_with(char::is_whitespace) {
                             cur.push(' ');
-                        }
-                        // Record the first heading's level for banner promotion.
-                        if !tc.current_cell.has_heading {
-                            tc.current_cell.has_heading = true;
-                            tc.current_cell.heading_level = level;
                         }
                     }
                     if !state.in_table_cell() {
@@ -930,75 +920,13 @@ fn html_grid_width(rows: &[HtmlRow]) -> usize {
         .min(MAX_TABLE_COLS)
 }
 
-/// Whether a row's cells exactly tile the full grid width.
-fn html_row_tiles(row: &HtmlRow, grid_width: usize) -> bool {
-    grid_width > 0 && row.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>() == grid_width
-}
-
-/// The layout role of an HTML table row (mirrors the DOCX classifier).
-#[derive(Debug, Clone, PartialEq)]
-enum HtmlRowKind {
-    Banner,
-    LabelValue,
-    Tiling,
-    Fallback,
-}
-
 /// Whether any cell in the row contains a nested table.
 ///
-/// Such rows cannot be flattened into single grid cells, so they are linearized
-/// (classified `Fallback`) and their nested tables emitted as standalone blocks.
+/// A nested table cannot live inside a single GFM cell, so a table containing one
+/// is linearized (its cells' text and nested tables emitted as standalone blocks)
+/// rather than rendered as a grid.
 fn html_row_has_nested_table(row: &HtmlRow) -> bool {
     row.cells.iter().any(|c| c.has_nested_table())
-}
-
-/// Classify a single HTML row by its cell layout. First matching rule wins.
-fn classify_html_row(row: &HtmlRow, grid_width: usize) -> HtmlRowKind {
-    let cells = &row.cells;
-    // A row whose cell holds a nested table cannot become a grid cell; linearize.
-    if html_row_has_nested_table(row) {
-        return HtmlRowKind::Fallback;
-    }
-    if cells.len() == 1 && grid_width >= 1 && cells[0].colspan.max(1) >= grid_width {
-        return HtmlRowKind::Banner;
-    }
-    // Label/value requires a non-empty label cell — an empty label (e.g. a
-    // vertical-merge placeholder) would render a bare `**:**`.
-    if cells.len() == 2
-        && grid_width >= 3
-        && cells[0].colspan.max(1) == 1
-        && cells[1].colspan.max(1) == grid_width - 1
-        && !cells[0].content.trim().is_empty()
-    {
-        return HtmlRowKind::LabelValue;
-    }
-    if html_row_tiles(row, grid_width) {
-        return HtmlRowKind::Tiling;
-    }
-    HtmlRowKind::Fallback
-}
-
-/// Whether a table is "simple": uniform widths, no spans, no header/data mixing.
-///
-/// Such tables render exactly as before (first row / `<thead>` as header),
-/// guaranteeing no regression for ordinary HTML tables.
-fn html_table_is_simple(rows: &[HtmlRow]) -> bool {
-    if rows.is_empty() {
-        return true;
-    }
-    // A nested table inside any cell forces the hybrid path so the inner table is
-    // emitted as a standalone block rather than escaped into a single cell.
-    if rows.iter().any(html_row_has_nested_table) {
-        return false;
-    }
-    // More than one header row cannot be represented by a single GFM header, so
-    // route it through the hybrid path (which renders header rows as a grid).
-    if rows.iter().filter(|r| r.is_header_row).count() > 1 {
-        return false;
-    }
-    let width = rows[0].cells.len();
-    rows.iter()
-        .all(|r| r.cells.len() == width && r.cells.iter().all(|c| c.colspan <= 1 && c.rowspan <= 1))
 }
 
 /// Expand a row's cells across `grid_width` columns for GFM rendering (empty-fill).
@@ -1035,11 +963,16 @@ fn render_html_grid(rows: &[&HtmlRow], grid_width: usize, plain: bool) -> String
 
 /// Render a completed table collector into a table string.
 ///
-/// Simple tables use the historical GFM path. Spanned/layout tables are
-/// linearized: banner rows become headings/bold paragraphs, label/value rows
-/// become `**Label:** value`, contiguous tiling rows become GFM tables, and
-/// irregular rows become small standalone tables. When `plain` is true the
-/// linearized parts flatten fully and grid parts stay tab-separated.
+/// Every table — uniform, merged, or layout — renders as a single GFM table of
+/// the authoritative grid width: horizontal spans are empty-filled, vertical
+/// spans (`rowspan`) are materialized as blank placeholder cells, and the first
+/// row is the header. This is deliberately uniform: a merged/layout table is kept
+/// as one table rather than being split into headings and `**Label:** value`
+/// lines, so structure stays consistent for downstream (LLM) consumers.
+///
+/// The one exception is a table that contains a nested table: a nested table
+/// cannot live inside a single GFM cell, so such a table is linearized — each
+/// cell's text and any nested table are emitted as standalone blocks.
 fn render_table(tc: &TableCollector, plain: bool) -> String {
     let rows = normalize_html_rowspans(&tc.rows);
     if rows.is_empty() {
@@ -1050,125 +983,44 @@ fn render_table(tc: &TableCollector, plain: bool) -> String {
         return String::new();
     }
 
-    // Simple table: historical behavior (header = thead row(s) or first row).
-    if html_table_is_simple(&rows) {
-        let header_idx = rows.iter().position(|r| r.is_header_row);
-        let (header_row, data): (&HtmlRow, Vec<&HtmlRow>) = match header_idx {
-            Some(i) => (&rows[i], rows.iter().filter(|r| !r.is_header_row).collect()),
-            None => (&rows[0], rows[1..].iter().collect()),
-        };
-        let headers: Vec<&str> = header_row
-            .cells
-            .iter()
-            .map(|c| c.content.as_str())
-            .collect();
-        if headers.is_empty() {
-            return String::new();
-        }
-        let data_refs: Vec<Vec<&str>> = data
-            .iter()
-            .map(|r| r.cells.iter().map(|c| c.content.as_str()).collect())
-            .collect();
-        return if plain {
-            markdown::build_table_plain(&headers, &data_refs)
-        } else {
-            markdown::build_table(&headers, &data_refs)
-        };
-    }
-
-    // Hybrid path: classify each row and coalesce contiguous tiling runs.
-    let mut out = String::new();
-    let mut grid_run: Vec<&HtmlRow> = Vec::new();
-    let flush_grid = |run: &mut Vec<&HtmlRow>, out: &mut String| {
-        if !run.is_empty() {
-            out.push_str(&render_html_grid(run, grid_width, plain));
-            out.push('\n');
-            run.clear();
-        }
-    };
-
-    for row in &rows {
-        match classify_html_row(row, grid_width) {
-            HtmlRowKind::Tiling => grid_run.push(row),
-            HtmlRowKind::Banner => {
-                flush_grid(&mut grid_run, &mut out);
-                let cell = &row.cells[0];
-                let text = cell.content.trim();
-                if text.is_empty() {
-                    continue;
-                }
-                if plain {
+    // A nested table cannot be a grid cell: linearize the whole table, emitting
+    // each cell's text and any nested table as standalone blocks in order.
+    if rows.iter().any(html_row_has_nested_table) {
+        let mut out = String::new();
+        for row in &rows {
+            for c in &row.cells {
+                let text = c.content.trim();
+                if !text.is_empty() {
                     out.push_str(text);
-                    out.push_str("\n\n");
-                } else if cell.has_heading {
-                    out.push_str(&markdown::format_heading(cell.heading_level, text));
                     out.push('\n');
-                } else {
-                    out.push_str(&format!("**{text}**\n\n"));
-                }
-            }
-            HtmlRowKind::LabelValue => {
-                flush_grid(&mut grid_run, &mut out);
-                let label_full = row.cells[0].content.trim();
-                // Strip a single trailing colon (we re-add one); keep extra colons.
-                let label = label_full.strip_suffix(':').unwrap_or(label_full);
-                let value = row.cells[1].content.trim();
-                if plain {
-                    out.push_str(label);
-                    out.push('\n');
-                    if !value.is_empty() {
-                        out.push_str(value);
+                    if !plain {
                         out.push('\n');
                     }
-                    out.push('\n');
-                } else {
-                    out.push_str(&format!("**{label}:** {value}\n\n"));
                 }
-            }
-            HtmlRowKind::Fallback => {
-                flush_grid(&mut grid_run, &mut out);
-                if html_row_has_nested_table(row) {
-                    // Emit each cell's text and any nested table as standalone
-                    // blocks, separated by blank lines, so a nested table is never
-                    // escaped into a single grid cell.
-                    for c in &row.cells {
-                        let text = c.content.trim();
-                        if !text.is_empty() {
-                            if plain {
-                                out.push_str(text);
-                                out.push('\n');
-                            } else {
-                                out.push_str(text);
-                                out.push_str("\n\n");
-                            }
-                        }
-                        if c.has_nested_table() {
-                            if plain {
-                                out.push_str(c.nested_plain.trim_end());
-                                out.push('\n');
-                            } else {
-                                out.push_str(c.nested_md.trim_end());
-                                out.push_str("\n\n");
-                            }
-                        }
-                    }
+                if c.has_nested_table() {
                     if plain {
+                        out.push_str(c.nested_plain.trim_end());
                         out.push('\n');
-                    }
-                } else {
-                    let texts: Vec<&str> = row.cells.iter().map(|c| c.content.as_str()).collect();
-                    if plain {
-                        out.push_str(&markdown::build_table_plain(&texts, &[]));
                     } else {
-                        out.push_str(&markdown::build_table(&texts, &[]));
+                        out.push_str(c.nested_md.trim_end());
+                        out.push_str("\n\n");
                     }
-                    out.push('\n');
                 }
             }
         }
+        if plain {
+            out.push('\n');
+        }
+        return out;
     }
-    flush_grid(&mut grid_run, &mut out);
-    out
+
+    // Common case: one empty-filled GFM grid over every row (row 0 is the header).
+    // Bound the rendered area (rows x grid_width) at MAX_TABLE_CELLS: since every
+    // cell is escaped and emitted, an extreme grid would otherwise produce
+    // gigabytes of markdown. Excess rows are dropped (best-effort truncation).
+    let max_rows = (MAX_TABLE_CELLS / grid_width).max(1);
+    let row_refs: Vec<&HtmlRow> = rows.iter().take(max_rows).collect();
+    render_html_grid(&row_refs, grid_width, plain)
 }
 
 #[cfg(test)]
@@ -1384,42 +1236,65 @@ mod tests {
     }
 
     #[test]
-    fn test_html_table_banner_bold() {
+    fn test_html_table_full_width_banner_is_grid_row() {
+        // A full-width colspan row stays a grid row (empty-filled), not a heading
+        // or bold paragraph.
         let html = r#"<table>
             <tr><td colspan="3">Section</td></tr>
             <tr><td>a</td><td>b</td><td>c</td></tr>
         </table>"#;
         let result = convert_html(html);
         assert!(
-            result.markdown.contains("**Section**"),
+            result.markdown.contains("| Section |  |  |"),
+            "banner not an empty-filled header: {}",
+            result.markdown
+        );
+        assert!(
+            result.markdown.contains("| a | b | c |"),
             "md: {}",
             result.markdown
         );
+        assert!(!result.markdown.contains('#'), "md: {}", result.markdown);
+        assert!(!result.markdown.contains("**"), "md: {}", result.markdown);
     }
 
     #[test]
-    fn test_html_table_banner_heading() {
+    fn test_html_table_heading_in_banner_inline() {
+        // A heading inside a full-width cell keeps its text inline in the grid cell
+        // (no `##` promotion).
         let html = r#"<table>
             <tr><td colspan="3"><h2>Section</h2></td></tr>
             <tr><td>a</td><td>b</td><td>c</td></tr>
         </table>"#;
         let result = convert_html(html);
         assert!(
-            result.markdown.contains("## Section"),
+            result.markdown.contains("| Section |  |  |"),
+            "md: {}",
+            result.markdown
+        );
+        assert!(
+            !result.markdown.contains("## Section"),
             "md: {}",
             result.markdown
         );
     }
 
     #[test]
-    fn test_html_table_label_value() {
+    fn test_html_table_label_value_kept_as_grid_row() {
+        // A narrow-label + wide-value row stays a grid row (empty-filled), not a
+        // `**Label:** value` line.
         let html = r#"<table>
             <tr><td>Date</td><td colspan="2">Monday</td></tr>
             <tr><td>a</td><td>b</td><td>c</td></tr>
         </table>"#;
         let result = convert_html(html);
         assert!(
-            result.markdown.contains("**Date:** Monday"),
+            result.markdown.contains("| Date | Monday |  |"),
+            "md: {}",
+            result.markdown
+        );
+        assert!(
+            !result.markdown.contains("**Date:**"),
             "md: {}",
             result.markdown
         );
@@ -1521,12 +1396,13 @@ mod tests {
     }
 
     #[test]
-    fn test_html_label_double_colon_preserved() {
+    fn test_html_label_colons_preserved_in_grid_cell() {
+        // A label cell keeps its text verbatim (colons included) as a grid cell.
         let html = r#"<table><tr><td>Ratio::</td><td colspan="2">val</td></tr><tr><td>p</td><td>q</td><td>r</td></tr></table>"#;
         let result = convert_html(html);
         assert!(
-            result.markdown.contains("**Ratio::** val"),
-            "colon collapsed: {}",
+            result.markdown.contains("| Ratio:: | val |  |"),
+            "label not a grid cell: {}",
             result.markdown
         );
     }
@@ -1596,10 +1472,11 @@ mod tests {
         let elapsed = start.elapsed();
 
         // Without the MAX_TABLE_CELLS cap this would materialize ~16.7M cells
-        // (~1.6 GB) and render to gigabytes of markdown. The cap bounds the cell
-        // count (~MAX_TABLE_CELLS), so the markdown stays small relative to that
-        // catastrophic baseline. A few MB is the bounded steady state; the speed
-        // assertion below is the real DoS guard (no quadratic O(rows*width) scan).
+        // (~1.6 GB) and, since every table renders as one GFM grid, escape and
+        // join all of them into gigabytes of markdown. The cap bounds the cell
+        // count (~MAX_TABLE_CELLS), so both the materialized cells and the rendered
+        // grid stay bounded. The speed assertion below is the real DoS guard (no
+        // quadratic O(rows*width) scan).
         assert!(
             result.markdown.len() < 8_000_000,
             "output not bounded: {} bytes",

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -4,7 +4,9 @@
 //! to produce Markdown. Supports headings, paragraphs, tables, lists, links,
 //! blockquotes, code blocks, bold/italic, and images.
 
-use crate::converter::{ConversionOptions, ConversionResult, Converter};
+use crate::converter::{
+    ConversionOptions, ConversionResult, ConversionWarning, Converter, WarningCode,
+};
 use crate::error::ConvertError;
 use crate::markdown;
 
@@ -56,12 +58,13 @@ impl Converter for HtmlConverter {
         let document = Html::parse_document(text);
 
         let title = extract_title(&document);
-        let (md, plain) = walk_dom(&document);
+        let (md, plain, warnings) = walk_dom(&document);
 
         Ok(ConversionResult {
             markdown: md,
             plain_text: plain,
             title,
+            warnings,
             ..Default::default()
         })
     }
@@ -105,6 +108,10 @@ struct WalkerState {
     /// Stack of table collectors; the top is the table currently being walked.
     /// A nested `<table>` inside a cell pushes a new frame.
     table_stack: Vec<TableCollector>,
+    /// Recoverable issues encountered while walking (e.g. a table truncated by a
+    /// resource cap). Surfaced in `ConversionResult.warnings` so best-effort
+    /// truncation is observable rather than silent.
+    warnings: Vec<ConversionWarning>,
 }
 
 struct ListContext {
@@ -123,27 +130,83 @@ struct PendingLink {
     start_pos: usize,
 }
 
-/// One buffered HTML table cell with span info and content.
+/// One ordered piece of a table cell's content.
+///
+/// A cell may interleave text and nested tables (e.g. `text<table>..</table>more`).
+/// Storing the pieces in document order — instead of one text string plus a
+/// separate nested-table string — preserves their relative position when the
+/// containing table is linearized. (Mirrors the DOCX cell-block model.)
+#[derive(Debug, Clone)]
+enum CellSegment {
+    /// Accumulated text run.
+    Text(String),
+    /// A fully-rendered nested table: `(markdown, plain_text)`. A nested table
+    /// cannot live inside a single GFM cell, so it is emitted as a standalone
+    /// block when the containing table is linearized.
+    Table {
+        /// Rendered markdown of the nested table.
+        md: String,
+        /// Plain-text form of the nested table.
+        plain: String,
+    },
+}
+
+/// One buffered HTML table cell with span info and ordered content segments.
 #[derive(Debug, Clone, Default)]
 struct HtmlCell {
     /// Columns this cell spans (`colspan`), always at least 1.
     colspan: usize,
     /// Rows this cell spans (`rowspan`), always at least 1.
     rowspan: usize,
-    /// Accumulated cell text.
-    content: String,
-    /// Rendered markdown of a nested table inside this cell, if any. Kept
-    /// separate from `content` so it is emitted as a standalone block rather than
-    /// escaped into a single grid cell.
-    nested_md: String,
-    /// Plain-text form of the nested table, paired with `nested_md`.
-    nested_plain: String,
+    /// Content in document order: text runs and nested tables interleaved.
+    segments: Vec<CellSegment>,
 }
 
 impl HtmlCell {
     /// Whether this cell contains a rendered nested table.
     fn has_nested_table(&self) -> bool {
-        !self.nested_md.is_empty()
+        self.segments
+            .iter()
+            .any(|s| matches!(s, CellSegment::Table { .. }))
+    }
+
+    /// Append text to the cell, extending the trailing `Text` segment if the last
+    /// segment is text, otherwise starting a new one. Keeps consecutive characters
+    /// in one segment so grid cells join cleanly.
+    fn push_text(&mut self, s: &str) {
+        if s.is_empty() {
+            return;
+        }
+        if let Some(CellSegment::Text(t)) = self.segments.last_mut() {
+            t.push_str(s);
+        } else {
+            self.segments.push(CellSegment::Text(s.to_string()));
+        }
+    }
+
+    /// Append a single space to the trailing text segment (used to separate two
+    /// block elements, e.g. two headings, inside one cell) only when the cell
+    /// already ends with non-whitespace text. Never starts a new segment and
+    /// never inserts space before a nested table.
+    fn push_separator_space(&mut self) {
+        if let Some(CellSegment::Text(t)) = self.segments.last_mut()
+            && !t.is_empty()
+            && !t.ends_with(char::is_whitespace)
+        {
+            t.push(' ');
+        }
+    }
+
+    /// Join all text segments into one string (nested tables omitted). Used for
+    /// the normal grid path where a cell becomes a single GFM cell. Trimmed.
+    fn joined_text(&self) -> String {
+        let mut s = String::new();
+        for seg in &self.segments {
+            if let CellSegment::Text(t) = seg {
+                s.push_str(t);
+            }
+        }
+        s.trim().to_string()
     }
 }
 
@@ -184,6 +247,7 @@ impl WalkerState {
             pending_heading: None,
             pending_link: None,
             table_stack: Vec::new(),
+            warnings: Vec::new(),
         }
     }
 
@@ -293,7 +357,7 @@ impl WalkerState {
 
 // ---- DOM walker ----
 
-fn walk_dom(document: &Html) -> (String, String) {
+fn walk_dom(document: &Html) -> (String, String, Vec<ConversionWarning>) {
     let mut state = WalkerState::new();
 
     for edge in document.root_element().traverse() {
@@ -314,7 +378,7 @@ fn walk_dom(document: &Html) -> (String, String) {
         plain + "\n"
     };
 
-    (md, plain)
+    (md, plain, state.warnings)
 }
 
 // ---- Element handlers (open) ----
@@ -338,10 +402,9 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     if let Some(tc) = state.table_stack.last_mut()
                         && tc.in_cell
                     {
-                        let cur = &mut tc.current_cell.content;
-                        if !cur.is_empty() && !cur.ends_with(char::is_whitespace) {
-                            cur.push(' ');
-                        }
+                        // Separate this heading's text from preceding cell text so
+                        // two headings in one cell do not mash together.
+                        tc.current_cell.push_separator_space();
                     }
                     if !state.in_table_cell() {
                         state.both_ensure_blank_line();
@@ -449,6 +512,8 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 "tr" => {
                     if let Some(tc) = state.table_stack.last_mut() {
                         tc.current_row = HtmlRow::default();
+                        // Read back in `render_table` to pick the GFM header row,
+                        // so a `<thead>` that does not appear first still wins.
                         tc.current_row.is_header_row = tc.in_header;
                     }
                 }
@@ -611,23 +676,19 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
             }
             "table" => {
                 if let Some(tc) = state.table_stack.pop() {
-                    let table_md = render_table(&tc, false);
-                    let table_plain = render_table(&tc, true);
+                    let table_md = render_table(&tc, false, &mut state.warnings);
+                    let table_plain = render_table(&tc, true, &mut Vec::new());
                     if state.table_stack.last().is_some_and(|p| p.in_cell) {
-                        // Nested table: stash its rendered output on the enclosing
-                        // cell (kept apart from the cell's text). The cell's row is
-                        // then linearized so the nested table renders as a block
-                        // instead of being escaped into a single grid cell.
+                        // Nested table: append it as a Table segment so it keeps its
+                        // document position relative to any text on either side. The
+                        // containing table is then linearized, emitting the nested
+                        // table as a standalone block rather than escaping it into a
+                        // single grid cell.
                         let parent = state.table_stack.last_mut().unwrap();
-                        if !parent.current_cell.nested_md.is_empty() {
-                            parent.current_cell.nested_md.push('\n');
-                            parent.current_cell.nested_plain.push('\n');
-                        }
-                        parent.current_cell.nested_md.push_str(table_md.trim_end());
-                        parent
-                            .current_cell
-                            .nested_plain
-                            .push_str(table_plain.trim_end());
+                        parent.current_cell.segments.push(CellSegment::Table {
+                            md: table_md.trim_end().to_string(),
+                            plain: table_plain.trim_end().to_string(),
+                        });
                     } else {
                         state.push_str(&table_md);
                         state.plain_push_str(&table_plain);
@@ -647,8 +708,10 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
             }
             "th" | "td" => {
                 if let Some(tc) = state.table_stack.last_mut() {
-                    let mut cell = std::mem::take(&mut tc.current_cell);
-                    cell.content = cell.content.trim().to_string();
+                    // Trimming now happens at read time (`joined_text` / the
+                    // linearize branch), matching how DOCX trims per-block; there is
+                    // no longer a single `content` field to trim here.
+                    let cell = std::mem::take(&mut tc.current_cell);
                     tc.current_row.cells.push(cell);
                     tc.in_cell = false;
                 }
@@ -671,10 +734,12 @@ fn handle_text(state: &mut WalkerState, text: &scraper::node::Text) {
 
     let raw = text.text.as_ref();
 
-    // Inside a table cell: accumulate into the cell buffer (shared for both outputs)
+    // Inside a table cell: accumulate into the cell's ordered segments (shared for
+    // both outputs). Extends the trailing text segment so text on either side of a
+    // nested table keeps its document position relative to the table.
     if let Some(tc) = state.table_stack.last_mut() {
         if tc.in_cell {
-            tc.current_cell.content.push_str(raw);
+            tc.current_cell.push_text(raw);
         }
         // Text outside cells but inside table (e.g. whitespace between tags) — ignore
         return;
@@ -791,7 +856,9 @@ fn collapse_whitespace(s: &str) -> String {
 /// number of materialized cells is capped at `MAX_TABLE_CELLS`. Both caps are
 /// no-ops for realistic tables and only truncate hostile inputs (e.g. a single
 /// `rowspan`x`colspan` cell that would otherwise expand quadratically).
-fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
+/// Returns the normalized rows and `true` if the `MAX_TABLE_CELLS` cap dropped
+/// cells (so the caller can emit a truncation warning).
+fn normalize_html_rowspans(rows: &[HtmlRow]) -> (Vec<HtmlRow>, bool) {
     // Provisional grid width: the widest row by summed colspan, capped so an
     // extreme colspan cannot drive unbounded per-column allocation. This is the
     // same quantity `html_grid_width` derives from the *normalized* rows, but
@@ -818,7 +885,7 @@ fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
                 is_header_row: row.is_header_row,
             });
         }
-        return out;
+        return (out, false);
     }
 
     // Carried spans, indexed by column: remaining rows still covered at `col`.
@@ -895,17 +962,18 @@ fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
 
         if total_cells >= MAX_TABLE_CELLS {
             // Truncate the remaining rows: emit them empty so downstream row
-            // count stays consistent without further allocation.
+            // count stays consistent without further allocation. This drops cell
+            // content, so report it to the caller.
             for r in &rows[out.len()..] {
                 out.push(HtmlRow {
                     cells: Vec::new(),
                     is_header_row: r.is_header_row,
                 });
             }
-            break;
+            return (out, true);
         }
     }
-    out
+    (out, false)
 }
 
 /// Authoritative grid width of an HTML table: the max over rows of summed colspan.
@@ -934,7 +1002,7 @@ fn expand_html_row(row: &HtmlRow, grid_width: usize) -> Vec<String> {
     let mut cols: Vec<String> = Vec::with_capacity(grid_width);
     for c in &row.cells {
         let span = c.colspan.max(1);
-        cols.push(c.content.trim().to_string());
+        cols.push(c.joined_text());
         for _ in 1..span {
             cols.push(String::new());
         }
@@ -965,16 +1033,24 @@ fn render_html_grid(rows: &[&HtmlRow], grid_width: usize, plain: bool) -> String
 ///
 /// Every table — uniform, merged, or layout — renders as a single GFM table of
 /// the authoritative grid width: horizontal spans are empty-filled, vertical
-/// spans (`rowspan`) are materialized as blank placeholder cells, and the first
-/// row is the header. This is deliberately uniform: a merged/layout table is kept
-/// as one table rather than being split into headings and `**Label:** value`
-/// lines, so structure stays consistent for downstream (LLM) consumers.
+/// spans (`rowspan`) are materialized as blank placeholder cells, and the header
+/// is the first row marked `is_header_row` (from `<thead>`) if any, else the first
+/// row. This is deliberately uniform: a merged/layout table is kept as one table
+/// rather than being split into headings and `**Label:** value` lines, so
+/// structure stays consistent for downstream (LLM) consumers.
 ///
 /// The one exception is a table that contains a nested table: a nested table
-/// cannot live inside a single GFM cell, so such a table is linearized — each
-/// cell's text and any nested table are emitted as standalone blocks.
-fn render_table(tc: &TableCollector, plain: bool) -> String {
-    let rows = normalize_html_rowspans(&tc.rows);
+/// cannot live inside a single GFM cell, so such a table is linearized as a WHOLE
+/// (per-table, not per-row) — each cell's text and any nested table are emitted as
+/// standalone blocks in document order. This whole-table linearization is
+/// intentional (consistency over prettiness): mixing a grid for some rows and
+/// blocks for others would be less predictable than one uniform block.
+///
+/// `warnings` collects best-effort truncations (rows/cells dropped by a resource
+/// cap) so they are observable rather than silent. Callers pass a throwaway sink
+/// for the plain-text render so identical truncations are not counted twice.
+fn render_table(tc: &TableCollector, plain: bool, warnings: &mut Vec<ConversionWarning>) -> String {
+    let (rows, cells_truncated) = normalize_html_rowspans(&tc.rows);
     if rows.is_empty() {
         return String::new();
     }
@@ -983,27 +1059,56 @@ fn render_table(tc: &TableCollector, plain: bool) -> String {
         return String::new();
     }
 
+    // #2: the grid width is capped at MAX_TABLE_COLS, so a row whose real cells sum
+    // to more than that has columns dropped. Detect it by comparing the rendered
+    // width against the widest row's raw summed colspan.
+    let raw_width = tc
+        .rows
+        .iter()
+        .map(|r| r.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>())
+        .max()
+        .unwrap_or(0);
+    let width_capped = raw_width > grid_width;
+
     // A nested table cannot be a grid cell: linearize the whole table, emitting
-    // each cell's text and any nested table as standalone blocks in order.
+    // each cell's text and any nested table as standalone blocks in document
+    // order. Iterating `segments` preserves text-before / text-after position
+    // around a nested table; successive nested tables are separated by a blank
+    // line so GFM does not fuse them.
     if rows.iter().any(html_row_has_nested_table) {
         let mut out = String::new();
         for row in &rows {
             for c in &row.cells {
-                let text = c.content.trim();
-                if !text.is_empty() {
-                    out.push_str(text);
-                    out.push('\n');
-                    if !plain {
-                        out.push('\n');
-                    }
-                }
-                if c.has_nested_table() {
-                    if plain {
-                        out.push_str(c.nested_plain.trim_end());
-                        out.push('\n');
-                    } else {
-                        out.push_str(c.nested_md.trim_end());
-                        out.push_str("\n\n");
+                for seg in &c.segments {
+                    match seg {
+                        CellSegment::Text(t) => {
+                            let text = t.trim();
+                            if !text.is_empty() {
+                                out.push_str(text);
+                                out.push('\n');
+                                if !plain {
+                                    out.push('\n');
+                                }
+                            }
+                        }
+                        CellSegment::Table { md, plain: tp } => {
+                            // Guarantee a blank line before the table so adjacent
+                            // blocks (text or another nested table) never fuse.
+                            if !plain && !out.is_empty() && !out.ends_with("\n\n") {
+                                if out.ends_with('\n') {
+                                    out.push('\n');
+                                } else {
+                                    out.push_str("\n\n");
+                                }
+                            }
+                            if plain {
+                                out.push_str(tp.trim_end());
+                                out.push('\n');
+                            } else {
+                                out.push_str(md.trim_end());
+                                out.push_str("\n\n");
+                            }
+                        }
                     }
                 }
             }
@@ -1011,16 +1116,79 @@ fn render_table(tc: &TableCollector, plain: bool) -> String {
         if plain {
             out.push('\n');
         }
+        if !plain {
+            push_table_truncation_warnings(warnings, cells_truncated, width_capped, false);
+        }
         return out;
     }
 
-    // Common case: one empty-filled GFM grid over every row (row 0 is the header).
+    // Common case: one empty-filled GFM grid. The header is the first row marked
+    // `is_header_row` (a `<thead>` row, which may not appear first in the source,
+    // e.g. `<tbody>` before `<thead>`); all OTHER rows render as the body in their
+    // original order. Falls back to row 0 as the header when no row is marked.
+    let header_idx = rows.iter().position(|r| r.is_header_row).unwrap_or(0);
+
     // Bound the rendered area (rows x grid_width) at MAX_TABLE_CELLS: since every
     // cell is escaped and emitted, an extreme grid would otherwise produce
     // gigabytes of markdown. Excess rows are dropped (best-effort truncation).
     let max_rows = (MAX_TABLE_CELLS / grid_width).max(1);
-    let row_refs: Vec<&HtmlRow> = rows.iter().take(max_rows).collect();
-    render_html_grid(&row_refs, grid_width, plain)
+    let rows_dropped = rows.len() > max_rows;
+
+    // Order the rows for rendering: header first, then every other row in source
+    // order. Then apply the row cap to the ordered list.
+    let mut ordered: Vec<&HtmlRow> = Vec::with_capacity(rows.len());
+    ordered.push(&rows[header_idx]);
+    for (i, r) in rows.iter().enumerate() {
+        if i != header_idx {
+            ordered.push(r);
+        }
+    }
+    ordered.truncate(max_rows);
+
+    if !plain {
+        push_table_truncation_warnings(warnings, cells_truncated, width_capped, rows_dropped);
+    }
+
+    render_html_grid(&ordered, grid_width, plain)
+}
+
+/// Append one `ResourceLimitReached` warning per distinct table truncation.
+///
+/// Best-effort conversion truncates rather than failing on extreme tables; each
+/// dropped-content case appends a structured warning so the loss is observable.
+fn push_table_truncation_warnings(
+    warnings: &mut Vec<ConversionWarning>,
+    cells_truncated: bool,
+    width_capped: bool,
+    rows_dropped: bool,
+) {
+    if cells_truncated {
+        warnings.push(ConversionWarning {
+            code: WarningCode::ResourceLimitReached,
+            message: format!(
+                "table exceeded the {MAX_TABLE_CELLS}-cell limit; trailing rows were truncated"
+            ),
+            location: None,
+        });
+    }
+    if width_capped {
+        warnings.push(ConversionWarning {
+            code: WarningCode::ResourceLimitReached,
+            message: format!(
+                "table row exceeded the {MAX_TABLE_COLS}-column limit; extra columns were dropped"
+            ),
+            location: None,
+        });
+    }
+    if rows_dropped {
+        warnings.push(ConversionWarning {
+            code: WarningCode::ResourceLimitReached,
+            message: format!(
+                "table exceeded the {MAX_TABLE_CELLS}-cell render limit; excess rows were dropped"
+            ),
+            location: None,
+        });
+    }
 }
 
 #[cfg(test)]
@@ -1775,5 +1943,228 @@ mod tests {
         assert!(result.markdown.contains("Unclosed paragraph"));
         assert!(result.markdown.contains("Another"));
         assert!(result.markdown.contains("Bold without close"));
+    }
+
+    // ---- Table review-follow-up tests ----
+
+    #[test]
+    fn test_html_thead_after_tbody_is_header() {
+        // Legal HTML: a <tbody> row may appear before the <thead> row. The GFM
+        // header must be the <thead> row, not whichever row came first.
+        let html = r#"<table><tbody><tr><td>d1</td><td>d2</td></tr></tbody><thead><tr><th>H1</th><th>H2</th></tr></thead></table>"#;
+        let result = convert_html(html);
+        // Header row (with separator immediately after) must be the thead row.
+        assert!(
+            result.markdown.contains("| H1 | H2 |\n|---|---|"),
+            "thead row not used as header: {}",
+            result.markdown
+        );
+        // The tbody row is the body, below the separator.
+        assert!(
+            result.markdown.contains("| d1 | d2 |"),
+            "data row missing: {}",
+            result.markdown
+        );
+        // Header must come before data.
+        let h = result.markdown.find("H1").unwrap();
+        let d = result.markdown.find("d1").unwrap();
+        assert!(h < d, "header not above body: {}", result.markdown);
+    }
+
+    #[test]
+    fn test_html_multi_row_thead_first_is_header_rest_body() {
+        // A two-row <thead>: only the FIRST header row can be the GFM header; the
+        // second header row must appear as the first body row (not dropped, not
+        // promoted), followed by the tbody row. Nothing is lost.
+        let html = r#"<table><thead><tr><th>H1a</th><th>H1b</th></tr><tr><th>H2a</th><th>H2b</th></tr></thead><tbody><tr><td>d1</td><td>d2</td></tr></tbody></table>"#;
+        let result = convert_html(html);
+        // First thead row is the header.
+        assert!(
+            result.markdown.contains("| H1a | H1b |\n|---|---|"),
+            "first header row not the GFM header: {}",
+            result.markdown
+        );
+        // Nothing lost.
+        for needle in ["H1a", "H1b", "H2a", "H2b", "d1", "d2"] {
+            assert!(
+                result.markdown.contains(needle),
+                "missing {needle}: {}",
+                result.markdown
+            );
+        }
+        // Body order: second header row, then the tbody row.
+        let h2 = result.markdown.find("H2a").unwrap();
+        let d1 = result.markdown.find("d1").unwrap();
+        assert!(
+            h2 < d1,
+            "second header row not before tbody row: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_nested_table_text_order_preserved() {
+        // Text before AND after a nested table in one cell must keep document order
+        // (outer, then the inner table, then after) and must NOT be glued
+        // ("outerafter").
+        let html = r#"<table><tr><td>outer<table><tr><td>x</td><td>y</td></tr></table>after</td><td>z</td></tr></table>"#;
+        let result = convert_html(html);
+        // The inner table is a standalone GFM block.
+        assert!(
+            result.markdown.contains("| x | y |"),
+            "inner table not a standalone block: {}",
+            result.markdown
+        );
+        // Not glued.
+        assert!(
+            !result.markdown.contains("outerafter"),
+            "outer and after were glued: {}",
+            result.markdown
+        );
+        // Source order: outer < inner table < after.
+        let outer = result.markdown.find("outer").unwrap();
+        let inner = result.markdown.find("| x | y |").unwrap();
+        let after = result.markdown.find("after").unwrap();
+        assert!(
+            outer < inner && inner < after,
+            "document order not preserved: {}",
+            result.markdown
+        );
+        // Plain text keeps order too and leaks no pipes.
+        let p_outer = result.plain_text.find("outer").unwrap();
+        let p_after = result.plain_text.find("after").unwrap();
+        assert!(
+            p_outer < p_after,
+            "plain order wrong: {:?}",
+            result.plain_text
+        );
+        assert!(
+            !result.plain_text.contains('|'),
+            "plain leaked pipes: {:?}",
+            result.plain_text
+        );
+    }
+
+    #[test]
+    fn test_html_sibling_nested_tables_not_fused() {
+        // Two nested tables in one cell must render as two separate GFM tables,
+        // separated by a blank line so GFM does not fuse them into one.
+        let html = r#"<table><tr><td><table><tr><td>a1</td><td>a2</td></tr></table><table><tr><td>b1</td><td>b2</td></tr></table></td><td>z</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("| a1 | a2 |"),
+            "first inner table missing: {}",
+            result.markdown
+        );
+        assert!(
+            result.markdown.contains("| b1 | b2 |"),
+            "second inner table missing: {}",
+            result.markdown
+        );
+        // A blank line must separate the two tables. Each single-row inner table
+        // renders as a header row plus a `|---|---|` separator (no data rows), so
+        // the boundary is the first table's separator, a blank line, then the
+        // second table's header — they are not fused into one GFM table.
+        assert!(
+            result.markdown.contains("|---|---|\n\n| b1 | b2 |"),
+            "sibling nested tables fused (no blank line between): {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_oversized_table_rows_dropped_warns() {
+        // A table with far more cells than MAX_TABLE_CELLS (here: a wide grid with
+        // many rows) must drop excess rows AND record a ResourceLimitReached
+        // warning so the truncation is observable, not silent.
+        let cols = 1000usize;
+        let rows = 200usize; // cols * rows = 200_000 > MAX_TABLE_CELLS (100_000)
+        let mut html = String::from("<table>");
+        for _ in 0..rows {
+            html.push_str("<tr>");
+            for c in 0..cols {
+                html.push_str("<td>");
+                html.push_str(&c.to_string());
+                html.push_str("</td>");
+            }
+            html.push_str("</tr>");
+        }
+        html.push_str("</table>");
+        let result = convert_html(&html);
+        assert!(
+            !result.warnings.is_empty(),
+            "no warning for truncated oversized table"
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == WarningCode::ResourceLimitReached),
+            "warning code not ResourceLimitReached: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_html_rowspan_colspan_product_truncation_warns() {
+        // The rowspan x colspan product cap in normalize_html_rowspans drops
+        // trailing rows' cells; that truncation must surface a warning.
+        let n = 4096;
+        let mut html = String::from("<table><tr>");
+        html.push_str(&format!(r#"<td rowspan="{n}" colspan="{n}">RC</td>"#));
+        html.push_str("</tr>");
+        for _ in 1..n {
+            html.push_str("<tr></tr>");
+        }
+        html.push_str("</table>");
+        let result = convert_html(&html);
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == WarningCode::ResourceLimitReached),
+            "no ResourceLimitReached warning for product-capped table: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_html_overwide_row_columns_dropped_warns() {
+        // A row whose real cells sum past MAX_TABLE_COLS (4096) is clipped by the
+        // width cap, dropping trailing real cells; that loss must surface a
+        // warning (#2). Here the first cell spans the whole cap, so the second
+        // real cell ("dropped") is truncated away.
+        let cap = 4096;
+        let html = format!(
+            r#"<table><tr><td colspan="{cap}">wide</td><td>dropped</td></tr><tr><td>a</td><td>b</td></tr></table>"#
+        );
+        let result = convert_html(&html);
+        // The trailing real cell is gone (width-clipped).
+        assert!(
+            !result.markdown.contains("dropped"),
+            "trailing cell unexpectedly survived: {}",
+            &result.markdown[..result.markdown.len().min(200)]
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.code == WarningCode::ResourceLimitReached),
+            "no ResourceLimitReached warning for over-width table: {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_html_normal_table_no_warnings() {
+        // A realistic table must produce NO warnings (truncation warnings only fire
+        // on resource-cap hits).
+        let html = r#"<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.warnings.is_empty(),
+            "unexpected warnings on a normal table: {:?}",
+            result.warnings
+        );
     }
 }

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -11,6 +11,17 @@ use crate::markdown;
 use ego_tree::iter::Edge;
 use scraper::{Html, Node};
 
+/// Upper bound on table columns / per-cell colspan.
+///
+/// Caps `colspan` so a malformed or hostile attribute cannot drive unbounded
+/// allocation when a row is expanded to the grid width. Far larger than any real
+/// table.
+const MAX_TABLE_COLS: usize = 4096;
+
+/// Upper bound on a cell's `rowspan`, limiting how many placeholder rows a single
+/// vertical span can materialize.
+const MAX_TABLE_ROWS: usize = 4096;
+
 /// Converts HTML files to Markdown.
 pub struct HtmlConverter;
 
@@ -109,6 +120,19 @@ struct HtmlCell {
     heading_level: u8,
     /// Accumulated cell text.
     content: String,
+    /// Rendered markdown of a nested table inside this cell, if any. Kept
+    /// separate from `content` so it is emitted as a standalone block rather than
+    /// escaped into a single grid cell.
+    nested_md: String,
+    /// Plain-text form of the nested table, paired with `nested_md`.
+    nested_plain: String,
+}
+
+impl HtmlCell {
+    /// Whether this cell contains a rendered nested table.
+    fn has_nested_table(&self) -> bool {
+        !self.nested_md.is_empty()
+    }
 }
 
 /// One buffered HTML table row.
@@ -300,10 +324,19 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     // text is still accumulated normally (no heading markers).
                     if let Some(tc) = state.table_stack.last_mut()
                         && tc.in_cell
-                        && !tc.current_cell.has_heading
                     {
-                        tc.current_cell.has_heading = true;
-                        tc.current_cell.heading_level = level;
+                        // Headings are block elements: separate their text from any
+                        // preceding cell content so multiple headings in one cell do
+                        // not mash together (e.g. "FirstSecond").
+                        let cur = &mut tc.current_cell.content;
+                        if !cur.is_empty() && !cur.ends_with(char::is_whitespace) {
+                            cur.push(' ');
+                        }
+                        // Record the first heading's level for banner promotion.
+                        if !tc.current_cell.has_heading {
+                            tc.current_cell.has_heading = true;
+                            tc.current_cell.heading_level = level;
+                        }
                     }
                     if !state.in_table_cell() {
                         state.both_ensure_blank_line();
@@ -415,23 +448,24 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     }
                 }
                 "th" | "td" => {
+                    // Clamp colspan/rowspan so a hostile attribute (e.g.
+                    // colspan="2000000000") cannot drive unbounded allocation when
+                    // the row is expanded to the grid width.
                     let colspan = el
                         .attr("colspan")
                         .and_then(|v| v.trim().parse::<usize>().ok())
                         .unwrap_or(1)
-                        .max(1);
+                        .clamp(1, MAX_TABLE_COLS);
                     let rowspan = el
                         .attr("rowspan")
                         .and_then(|v| v.trim().parse::<usize>().ok())
                         .unwrap_or(1)
-                        .max(1);
+                        .clamp(1, MAX_TABLE_ROWS);
                     if let Some(tc) = state.table_stack.last_mut() {
                         tc.current_cell = HtmlCell {
                             colspan,
                             rowspan,
-                            has_heading: false,
-                            heading_level: 0,
-                            content: String::new(),
+                            ..Default::default()
                         };
                         tc.in_cell = true;
                     }
@@ -575,15 +609,20 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                     let table_md = render_table(&tc, false);
                     let table_plain = render_table(&tc, true);
                     if state.table_stack.last().is_some_and(|p| p.in_cell) {
-                        // Nested table: append its rendered output into the
-                        // enclosing cell so it renders in place.
+                        // Nested table: stash its rendered output on the enclosing
+                        // cell (kept apart from the cell's text). The cell's row is
+                        // then linearized so the nested table renders as a block
+                        // instead of being escaped into a single grid cell.
                         let parent = state.table_stack.last_mut().unwrap();
-                        if !parent.current_cell.content.is_empty()
-                            && !parent.current_cell.content.ends_with('\n')
-                        {
-                            parent.current_cell.content.push('\n');
+                        if !parent.current_cell.nested_md.is_empty() {
+                            parent.current_cell.nested_md.push('\n');
+                            parent.current_cell.nested_plain.push('\n');
                         }
-                        parent.current_cell.content.push_str(table_md.trim_end());
+                        parent.current_cell.nested_md.push_str(table_md.trim_end());
+                        parent
+                            .current_cell
+                            .nested_plain
+                            .push_str(table_plain.trim_end());
                     } else {
                         state.push_str(&table_md);
                         state.plain_push_str(&table_plain);
@@ -799,11 +838,15 @@ fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
 }
 
 /// Authoritative grid width of an HTML table: the max over rows of summed colspan.
+///
+/// Bounded by `MAX_TABLE_COLS` so an extreme colspan cannot drive unbounded
+/// column allocation downstream.
 fn html_grid_width(rows: &[HtmlRow]) -> usize {
     rows.iter()
         .map(|r| r.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>())
         .max()
         .unwrap_or(0)
+        .min(MAX_TABLE_COLS)
 }
 
 /// Whether a row's cells exactly tile the full grid width.
@@ -820,16 +863,31 @@ enum HtmlRowKind {
     Fallback,
 }
 
+/// Whether any cell in the row contains a nested table.
+///
+/// Such rows cannot be flattened into single grid cells, so they are linearized
+/// (classified `Fallback`) and their nested tables emitted as standalone blocks.
+fn html_row_has_nested_table(row: &HtmlRow) -> bool {
+    row.cells.iter().any(|c| c.has_nested_table())
+}
+
 /// Classify a single HTML row by its cell layout. First matching rule wins.
 fn classify_html_row(row: &HtmlRow, grid_width: usize) -> HtmlRowKind {
     let cells = &row.cells;
+    // A row whose cell holds a nested table cannot become a grid cell; linearize.
+    if html_row_has_nested_table(row) {
+        return HtmlRowKind::Fallback;
+    }
     if cells.len() == 1 && grid_width >= 1 && cells[0].colspan.max(1) >= grid_width {
         return HtmlRowKind::Banner;
     }
+    // Label/value requires a non-empty label cell — an empty label (e.g. a
+    // vertical-merge placeholder) would render a bare `**:**`.
     if cells.len() == 2
         && grid_width >= 3
         && cells[0].colspan.max(1) == 1
         && cells[1].colspan.max(1) == grid_width - 1
+        && !cells[0].content.trim().is_empty()
     {
         return HtmlRowKind::LabelValue;
     }
@@ -846,6 +904,16 @@ fn classify_html_row(row: &HtmlRow, grid_width: usize) -> HtmlRowKind {
 fn html_table_is_simple(rows: &[HtmlRow]) -> bool {
     if rows.is_empty() {
         return true;
+    }
+    // A nested table inside any cell forces the hybrid path so the inner table is
+    // emitted as a standalone block rather than escaped into a single cell.
+    if rows.iter().any(html_row_has_nested_table) {
+        return false;
+    }
+    // More than one header row cannot be represented by a single GFM header, so
+    // route it through the hybrid path (which renders header rows as a grid).
+    if rows.iter().filter(|r| r.is_header_row).count() > 1 {
+        return false;
     }
     let width = rows[0].cells.len();
     rows.iter()
@@ -960,7 +1028,9 @@ fn render_table(tc: &TableCollector, plain: bool) -> String {
             }
             HtmlRowKind::LabelValue => {
                 flush_grid(&mut grid_run, &mut out);
-                let label = row.cells[0].content.trim().trim_end_matches(':');
+                let label_full = row.cells[0].content.trim();
+                // Strip a single trailing colon (we re-add one); keep extra colons.
+                let label = label_full.strip_suffix(':').unwrap_or(label_full);
                 let value = row.cells[1].content.trim();
                 if plain {
                     out.push_str(label);
@@ -976,13 +1046,43 @@ fn render_table(tc: &TableCollector, plain: bool) -> String {
             }
             HtmlRowKind::Fallback => {
                 flush_grid(&mut grid_run, &mut out);
-                let texts: Vec<&str> = row.cells.iter().map(|c| c.content.as_str()).collect();
-                if plain {
-                    out.push_str(&markdown::build_table_plain(&texts, &[]));
+                if html_row_has_nested_table(row) {
+                    // Emit each cell's text and any nested table as standalone
+                    // blocks, separated by blank lines, so a nested table is never
+                    // escaped into a single grid cell.
+                    for c in &row.cells {
+                        let text = c.content.trim();
+                        if !text.is_empty() {
+                            if plain {
+                                out.push_str(text);
+                                out.push('\n');
+                            } else {
+                                out.push_str(text);
+                                out.push_str("\n\n");
+                            }
+                        }
+                        if c.has_nested_table() {
+                            if plain {
+                                out.push_str(c.nested_plain.trim_end());
+                                out.push('\n');
+                            } else {
+                                out.push_str(c.nested_md.trim_end());
+                                out.push_str("\n\n");
+                            }
+                        }
+                    }
+                    if plain {
+                        out.push('\n');
+                    }
                 } else {
-                    out.push_str(&markdown::build_table(&texts, &[]));
+                    let texts: Vec<&str> = row.cells.iter().map(|c| c.content.as_str()).collect();
+                    if plain {
+                        out.push_str(&markdown::build_table_plain(&texts, &[]));
+                    } else {
+                        out.push_str(&markdown::build_table(&texts, &[]));
+                    }
+                    out.push('\n');
                 }
-                out.push('\n');
             }
         }
     }
@@ -1282,6 +1382,116 @@ mod tests {
                 result.markdown
             );
         }
+        // The inner table renders as a real GFM table, not escaped into a cell.
+        assert!(
+            result.markdown.contains("| inner1 | inner2 |"),
+            "inner table mangled: {}",
+            result.markdown
+        );
+        // No escaped pipes leaking from a crammed nested table.
+        assert!(
+            !result.markdown.contains("\\|"),
+            "escaped pipes leaked: {}",
+            result.markdown
+        );
+        // Plain text must not contain raw GFM pipe rows from the inner table.
+        assert!(
+            !result.plain_text.contains("|---|"),
+            "plain text leaked table syntax: {:?}",
+            result.plain_text
+        );
+    }
+
+    #[test]
+    fn test_html_nested_table_in_simple_outer() {
+        // A nested table inside an otherwise-uniform (no-span) outer table must
+        // still render as a standalone block, not be flattened into one cell.
+        let html = r#"<table><tr><td>a<table><tr><td>x</td><td>y</td></tr></table></td><td>b</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("| x | y |"),
+            "inner table mangled: {}",
+            result.markdown
+        );
+        assert!(
+            !result.markdown.contains("<br>") && !result.markdown.contains("\\|"),
+            "nested table crammed into a cell: {}",
+            result.markdown
+        );
+        assert!(
+            !result.plain_text.contains('|'),
+            "plain text leaked pipes: {:?}",
+            result.plain_text
+        );
+    }
+
+    #[test]
+    fn test_html_rowspan_colspan_no_empty_label() {
+        // A rowspan placeholder followed by a colspan value must not be rendered as
+        // an empty-label `**:**` line.
+        let html = r#"<table><tr><td rowspan="2">R</td><td>a</td></tr><tr><td colspan="2">wide</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            !result.markdown.contains("**:**"),
+            "empty-label artifact: {}",
+            result.markdown
+        );
+        assert!(result.markdown.contains("wide"), "md: {}", result.markdown);
+    }
+
+    #[test]
+    fn test_html_label_double_colon_preserved() {
+        let html = r#"<table><tr><td>Ratio::</td><td colspan="2">val</td></tr><tr><td>p</td><td>q</td><td>r</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("**Ratio::** val"),
+            "colon collapsed: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_multi_row_thead_preserved() {
+        // A two-row <thead> must not silently drop the second header row.
+        let html = r#"<table><thead><tr><th>H1a</th><th>H1b</th></tr><tr><th>H2a</th><th>H2b</th></tr></thead><tbody><tr><td>d1</td><td>d2</td></tr></tbody></table>"#;
+        let result = convert_html(html);
+        for needle in ["H1a", "H1b", "H2a", "H2b", "d1", "d2"] {
+            assert!(
+                result.markdown.contains(needle),
+                "header/data dropped: missing {needle}: {}",
+                result.markdown
+            );
+        }
+    }
+
+    #[test]
+    fn test_html_multi_heading_banner_separated() {
+        // Two headings in one banner cell must not mash into "FirstSecond".
+        let html = r#"<table><tr><td colspan="2"><h1>First</h1><h3>Second</h3></td></tr><tr><td>a</td><td>b</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            !result.markdown.contains("FirstSecond"),
+            "headings mashed: {}",
+            result.markdown
+        );
+        assert!(
+            result.markdown.contains("First Second"),
+            "md: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_colspan_bounded_no_dos() {
+        // A huge colspan in a tiling row must not allocate unbounded output.
+        let html = r#"<table><tr><td colspan="1000000">X</td><td>Y</td></tr><tr><td colspan="1000000">P</td><td>Q</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.len() < 100_000,
+            "output not bounded: {} bytes",
+            result.markdown.len()
+        );
+        assert!(result.markdown.contains('X'));
     }
 
     #[test]

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -22,6 +22,21 @@ const MAX_TABLE_COLS: usize = 4096;
 /// vertical span can materialize.
 const MAX_TABLE_ROWS: usize = 4096;
 
+/// Upper bound on the total number of grid cells materialized while resolving
+/// `rowspan` placeholders across an entire table.
+///
+/// `colspan` and `rowspan` are each clamped to 4096 independently, but their
+/// product is not, so a single `<td rowspan="4096" colspan="4096">` followed by
+/// thousands of empty `<tr>` rows could otherwise expand to ~16.7M cells
+/// (gigabytes of `HtmlCell`). This cap bounds the *product*: normalization stops
+/// emitting once the running total of output cells reaches this value
+/// (best-effort truncation, matching the silent style of the per-cell clamps).
+///
+/// 1_000_000 is far larger than any real-world table (a 1000x1000 grid) yet
+/// keeps peak `HtmlCell` allocation to the low hundreds of MB worst case, which
+/// is acceptable for a best-effort converter.
+const MAX_TABLE_CELLS: usize = 1_000_000;
+
 /// Converts HTML files to Markdown.
 pub struct HtmlConverter;
 
@@ -775,31 +790,79 @@ fn collapse_whitespace(s: &str) -> String {
 ///
 /// HTML declares a vertical span on the top cell and omits the covered columns
 /// from subsequent rows. To get a rectangular grid, each spanned column is
-/// re-materialized as an empty cell in the rows it covers. Tracking uses an
-/// ordered list of `(column_index, remaining_rows)`, never a hash map, so output
-/// stays deterministic.
+/// re-materialized as an empty cell in the rows it covers.
+///
+/// Carried vertical spans are tracked in a column-indexed `Vec<usize>` (the
+/// remaining rows still covered at each column), never a hash map, so coverage
+/// lookup is O(1), per-row bookkeeping is O(width), and output stays
+/// deterministic. The grid is bounded on two axes: each output row is capped at
+/// the table's provisional width (max summed `colspan` over rows, itself capped
+/// at `MAX_TABLE_COLS`) so a stray span cannot push a row past it, and the total
+/// number of materialized cells is capped at `MAX_TABLE_CELLS`. Both caps are
+/// no-ops for realistic tables and only truncate hostile inputs (e.g. a single
+/// `rowspan`x`colspan` cell that would otherwise expand quadratically).
 fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
-    // Pending spans carried from earlier rows: (column, rows still to fill).
-    let mut pending: Vec<(usize, usize)> = Vec::new();
+    // Provisional grid width: the widest row by summed colspan, capped so an
+    // extreme colspan cannot drive unbounded per-column allocation. This is the
+    // same quantity `html_grid_width` derives from the *normalized* rows, but
+    // computed up front from the raw rows so it can bound the work below.
+    let width = rows
+        .iter()
+        .map(|r| {
+            r.cells
+                .iter()
+                .map(|c| c.colspan.max(1))
+                .sum::<usize>()
+                .min(MAX_TABLE_COLS)
+        })
+        .max()
+        .unwrap_or(0)
+        .min(MAX_TABLE_COLS);
+
     let mut out: Vec<HtmlRow> = Vec::with_capacity(rows.len());
+    if width == 0 {
+        // No columns anywhere: preserve the (empty) rows verbatim.
+        for row in rows {
+            out.push(HtmlRow {
+                cells: Vec::new(),
+                is_header_row: row.is_header_row,
+            });
+        }
+        return out;
+    }
+
+    // Carried spans, indexed by column: remaining rows still covered at `col`.
+    // O(1) coverage lookup, O(width) decrement per row, no hash map.
+    let mut pending: Vec<usize> = vec![0; width];
+    // Spans started by THIS row; applied only after the current row's carried
+    // spans are decremented, so a cell never covers its own row.
+    let mut new_spans: Vec<usize> = vec![0; width];
+    // Running total of emitted cells across all output rows (memory bound).
+    let mut total_cells = 0usize;
 
     for row in rows {
+        new_spans.iter_mut().for_each(|s| *s = 0);
         let mut new_cells: Vec<HtmlCell> = Vec::new();
-        // Spans started by cells in THIS row; added to `pending` only after the
-        // current row's old spans are decremented, so they survive to next row.
-        let mut new_spans: Vec<(usize, usize)> = Vec::new();
         let mut col = 0usize;
         let mut src = row.cells.iter();
         let mut next = src.next();
 
-        loop {
-            if pending.iter().any(|(c, _)| *c == col) {
+        // Materialize columns left-to-right until the row reaches the grid width.
+        // The width cap is what makes the per-row work bounded; the original loop
+        // terminated on `next == None` with the column not covered, which for
+        // realistic tables coincides with `col == width`.
+        while col < width {
+            if total_cells >= MAX_TABLE_CELLS {
+                break;
+            }
+            if pending[col] > 0 {
                 // A vertical span from an earlier row covers this column.
                 new_cells.push(HtmlCell {
                     colspan: 1,
                     rowspan: 1,
                     ..Default::default()
                 });
+                total_cells += 1;
                 col += 1;
                 continue;
             }
@@ -808,31 +871,49 @@ fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
                     let colspan = cell.colspan.max(1);
                     if cell.rowspan > 1 {
                         for k in 0..colspan {
-                            new_spans.push((col + k, cell.rowspan - 1));
+                            let c = col + k;
+                            if c < width {
+                                new_spans[c] = cell.rowspan - 1;
+                            }
                         }
                     }
                     let mut c = cell.clone();
                     c.rowspan = 1;
                     new_cells.push(c);
+                    total_cells += 1;
                     col += colspan;
                     next = src.next();
                 }
+                // No carried span here and no source cells left: the row is
+                // complete (matches the original loop's `None` break). Trailing
+                // carried columns past the last real cell are still filled above
+                // because `pending[col] > 0` is checked before `next`.
                 None => break,
             }
         }
 
-        // Every old span covered exactly this row: decrement and drop exhausted.
-        pending = pending
-            .into_iter()
-            .filter_map(|(c, n)| n.checked_sub(1).filter(|&n| n > 0).map(|n| (c, n)))
-            .collect();
-        // Now register spans started this row so they apply to following rows.
-        pending.extend(new_spans);
+        // Every carried span covered exactly this row: decrement and drop the
+        // exhausted ones, then layer in the spans started by this row.
+        for (p, n) in pending.iter_mut().zip(new_spans.iter()) {
+            *p = p.saturating_sub(1).max(*n);
+        }
 
         out.push(HtmlRow {
             cells: new_cells,
             is_header_row: row.is_header_row,
         });
+
+        if total_cells >= MAX_TABLE_CELLS {
+            // Truncate the remaining rows: emit them empty so downstream row
+            // count stays consistent without further allocation.
+            for r in &rows[out.len()..] {
+                out.push(HtmlRow {
+                    cells: Vec::new(),
+                    is_header_row: r.is_header_row,
+                });
+            }
+            break;
+        }
     }
     out
 }
@@ -1492,6 +1573,66 @@ mod tests {
             result.markdown.len()
         );
         assert!(result.markdown.contains('X'));
+    }
+
+    #[test]
+    fn test_html_rowspan_colspan_product_bounded_no_dos() {
+        // A single <td rowspan=N colspan=N> followed by N-1 empty <tr> rows would,
+        // before the MAX_TABLE_CELLS cap, materialize ~N*N placeholder cells
+        // (~16.7M for N=4096) via normalize_html_rowspans. This exercises the
+        // ACTUAL normalize/expand path (the colspan-only DoS test hits Fallback and
+        // never expands). The result must be produced quickly and stay bounded.
+        let n = 4096;
+        let mut html = String::from("<table><tr>");
+        html.push_str(&format!(r#"<td rowspan="{n}" colspan="{n}">RC</td>"#));
+        html.push_str("</tr>");
+        for _ in 1..n {
+            html.push_str("<tr></tr>");
+        }
+        html.push_str("</table>");
+
+        let start = std::time::Instant::now();
+        let result = convert_html(&html);
+        let elapsed = start.elapsed();
+
+        // Without the MAX_TABLE_CELLS cap this would materialize ~16.7M cells
+        // (~1.6 GB) and render to gigabytes of markdown. The cap bounds the cell
+        // count (~MAX_TABLE_CELLS), so the markdown stays small relative to that
+        // catastrophic baseline. A few MB is the bounded steady state; the speed
+        // assertion below is the real DoS guard (no quadratic O(rows*width) scan).
+        assert!(
+            result.markdown.len() < 8_000_000,
+            "output not bounded: {} bytes",
+            result.markdown.len()
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "normalize too slow: {elapsed:?}"
+        );
+        assert!(
+            result.markdown.contains("RC"),
+            "content dropped: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_rowspan_colspan_same_cell_grid() {
+        // A cell that spans 2 rows AND 2 columns simultaneously. The header row
+        // shows the real cell, one in-cell colspan blank, then the trailing cell;
+        // the data row shows two rowspan placeholders, then its own cell.
+        let html = r#"<table><tr><td rowspan="2" colspan="2">RC</td><td>X</td></tr><tr><td>Y</td></tr></table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("| RC |  | X |"),
+            "header grid wrong: {}",
+            result.markdown
+        );
+        assert!(
+            result.markdown.contains("|  |  | Y |"),
+            "data grid wrong: {}",
+            result.markdown
+        );
     }
 
     #[test]

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -75,7 +75,9 @@ struct WalkerState {
     plain_trailing_newlines: usize,
     pending_heading: Option<PendingHeading>,
     pending_link: Option<PendingLink>,
-    table_collector: Option<TableCollector>,
+    /// Stack of table collectors; the top is the table currently being walked.
+    /// A nested `<table>` inside a cell pushes a new frame.
+    table_stack: Vec<TableCollector>,
 }
 
 struct ListContext {
@@ -94,12 +96,41 @@ struct PendingLink {
     start_pos: usize,
 }
 
+/// One buffered HTML table cell with span info and content.
+#[derive(Debug, Clone, Default)]
+struct HtmlCell {
+    /// Columns this cell spans (`colspan`), always at least 1.
+    colspan: usize,
+    /// Rows this cell spans (`rowspan`), always at least 1.
+    rowspan: usize,
+    /// True when the cell contains a heading element (`<h1>`..`<h6>`).
+    has_heading: bool,
+    /// Heading level of the first contained heading, if any (for banner promotion).
+    heading_level: u8,
+    /// Accumulated cell text.
+    content: String,
+}
+
+/// One buffered HTML table row.
+#[derive(Debug, Clone, Default)]
+struct HtmlRow {
+    /// Cells in document order.
+    cells: Vec<HtmlCell>,
+    /// True if this row came from `<thead>`.
+    is_header_row: bool,
+}
+
+/// Buffers an HTML table while its elements are walked.
 struct TableCollector {
-    headers: Vec<String>,
-    rows: Vec<Vec<String>>,
-    current_row: Vec<String>,
-    current_cell: String,
+    /// Completed rows, in document order.
+    rows: Vec<HtmlRow>,
+    /// In-progress row.
+    current_row: HtmlRow,
+    /// In-progress cell.
+    current_cell: HtmlCell,
+    /// Whether the current row is inside `<thead>`.
     in_header: bool,
+    /// Whether a `<th>`/`<td>` is currently open.
     in_cell: bool,
 }
 
@@ -116,7 +147,7 @@ impl WalkerState {
             plain_trailing_newlines: 0,
             pending_heading: None,
             pending_link: None,
-            table_collector: None,
+            table_stack: Vec::new(),
         }
     }
 
@@ -220,7 +251,7 @@ impl WalkerState {
     }
 
     fn in_table_cell(&self) -> bool {
-        self.table_collector.as_ref().is_some_and(|tc| tc.in_cell)
+        self.table_stack.last().is_some_and(|tc| tc.in_cell)
     }
 }
 
@@ -263,13 +294,25 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 }
                 _ if state.skip_depth > 0 => {}
                 "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
-                    state.both_ensure_blank_line();
                     let level = tag[1..].parse::<u8>().unwrap_or(1);
-                    state.pending_heading = Some(PendingHeading {
-                        level,
-                        start_pos: state.output.len(),
-                        plain_start_pos: state.plain_output.len(),
-                    });
+                    // A heading inside a table cell is recorded on the cell so a
+                    // banner row can be promoted to that heading level; the cell's
+                    // text is still accumulated normally (no heading markers).
+                    if let Some(tc) = state.table_stack.last_mut()
+                        && tc.in_cell
+                        && !tc.current_cell.has_heading
+                    {
+                        tc.current_cell.has_heading = true;
+                        tc.current_cell.heading_level = level;
+                    }
+                    if !state.in_table_cell() {
+                        state.both_ensure_blank_line();
+                        state.pending_heading = Some(PendingHeading {
+                            level,
+                            start_pos: state.output.len(),
+                            plain_start_pos: state.plain_output.len(),
+                        });
+                    }
                 }
                 "p" if !state.in_table_cell() => {
                     state.both_ensure_blank_line();
@@ -346,33 +389,50 @@ fn handle_open(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 }
                 "table" => {
                     state.both_ensure_blank_line();
-                    state.table_collector = Some(TableCollector {
-                        headers: Vec::new(),
+                    // Push a new table frame (supports nested tables).
+                    state.table_stack.push(TableCollector {
                         rows: Vec::new(),
-                        current_row: Vec::new(),
-                        current_cell: String::new(),
+                        current_row: HtmlRow::default(),
+                        current_cell: HtmlCell::default(),
                         in_header: false,
                         in_cell: false,
                     });
                 }
                 "thead" => {
-                    if let Some(tc) = &mut state.table_collector {
+                    if let Some(tc) = state.table_stack.last_mut() {
                         tc.in_header = true;
                     }
                 }
                 "tbody" => {
-                    if let Some(tc) = &mut state.table_collector {
+                    if let Some(tc) = state.table_stack.last_mut() {
                         tc.in_header = false;
                     }
                 }
                 "tr" => {
-                    if let Some(tc) = &mut state.table_collector {
-                        tc.current_row = Vec::new();
+                    if let Some(tc) = state.table_stack.last_mut() {
+                        tc.current_row = HtmlRow::default();
+                        tc.current_row.is_header_row = tc.in_header;
                     }
                 }
                 "th" | "td" => {
-                    if let Some(tc) = &mut state.table_collector {
-                        tc.current_cell = String::new();
+                    let colspan = el
+                        .attr("colspan")
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(1)
+                        .max(1);
+                    let rowspan = el
+                        .attr("rowspan")
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(1)
+                        .max(1);
+                    if let Some(tc) = state.table_stack.last_mut() {
+                        tc.current_cell = HtmlCell {
+                            colspan,
+                            rowspan,
+                            has_heading: false,
+                            heading_level: 0,
+                            content: String::new(),
+                        };
                         tc.in_cell = true;
                     }
                 }
@@ -511,30 +571,41 @@ fn handle_close(state: &mut WalkerState, node: &ego_tree::NodeRef<Node>) {
                 state.both_ensure_newline();
             }
             "table" => {
-                if let Some(tc) = state.table_collector.take() {
+                if let Some(tc) = state.table_stack.pop() {
                     let table_md = render_table(&tc, false);
-                    state.push_str(&table_md);
                     let table_plain = render_table(&tc, true);
-                    state.plain_push_str(&table_plain);
-                }
-            }
-            "thead" => {
-                // in_header handled by tbody open or next row
-            }
-            "tr" => {
-                if let Some(tc) = &mut state.table_collector {
-                    let row = std::mem::take(&mut tc.current_row);
-                    if tc.in_header {
-                        tc.headers = row;
+                    if state.table_stack.last().is_some_and(|p| p.in_cell) {
+                        // Nested table: append its rendered output into the
+                        // enclosing cell so it renders in place.
+                        let parent = state.table_stack.last_mut().unwrap();
+                        if !parent.current_cell.content.is_empty()
+                            && !parent.current_cell.content.ends_with('\n')
+                        {
+                            parent.current_cell.content.push('\n');
+                        }
+                        parent.current_cell.content.push_str(table_md.trim_end());
                     } else {
-                        tc.rows.push(row);
+                        state.push_str(&table_md);
+                        state.plain_push_str(&table_plain);
                     }
                 }
             }
+            "thead" => {
+                if let Some(tc) = state.table_stack.last_mut() {
+                    tc.in_header = false;
+                }
+            }
+            "tr" => {
+                if let Some(tc) = state.table_stack.last_mut() {
+                    let row = std::mem::take(&mut tc.current_row);
+                    tc.rows.push(row);
+                }
+            }
             "th" | "td" => {
-                if let Some(tc) = &mut state.table_collector {
-                    let cell = std::mem::take(&mut tc.current_cell);
-                    tc.current_row.push(cell.trim().to_string());
+                if let Some(tc) = state.table_stack.last_mut() {
+                    let mut cell = std::mem::take(&mut tc.current_cell);
+                    cell.content = cell.content.trim().to_string();
+                    tc.current_row.cells.push(cell);
                     tc.in_cell = false;
                 }
             }
@@ -557,10 +628,9 @@ fn handle_text(state: &mut WalkerState, text: &scraper::node::Text) {
     let raw = text.text.as_ref();
 
     // Inside a table cell: accumulate into the cell buffer (shared for both outputs)
-    if let Some(tc) = &mut state.table_collector {
+    if let Some(tc) = state.table_stack.last_mut() {
         if tc.in_cell {
-            tc.current_cell.push_str(raw);
-            return;
+            tc.current_cell.content.push_str(raw);
         }
         // Text outside cells but inside table (e.g. whitespace between tags) — ignore
         return;
@@ -662,32 +732,262 @@ fn collapse_whitespace(s: &str) -> String {
     result
 }
 
+/// Resolve `rowspan` by inserting empty placeholder cells into lower rows.
+///
+/// HTML declares a vertical span on the top cell and omits the covered columns
+/// from subsequent rows. To get a rectangular grid, each spanned column is
+/// re-materialized as an empty cell in the rows it covers. Tracking uses an
+/// ordered list of `(column_index, remaining_rows)`, never a hash map, so output
+/// stays deterministic.
+fn normalize_html_rowspans(rows: &[HtmlRow]) -> Vec<HtmlRow> {
+    // Pending spans carried from earlier rows: (column, rows still to fill).
+    let mut pending: Vec<(usize, usize)> = Vec::new();
+    let mut out: Vec<HtmlRow> = Vec::with_capacity(rows.len());
+
+    for row in rows {
+        let mut new_cells: Vec<HtmlCell> = Vec::new();
+        // Spans started by cells in THIS row; added to `pending` only after the
+        // current row's old spans are decremented, so they survive to next row.
+        let mut new_spans: Vec<(usize, usize)> = Vec::new();
+        let mut col = 0usize;
+        let mut src = row.cells.iter();
+        let mut next = src.next();
+
+        loop {
+            if pending.iter().any(|(c, _)| *c == col) {
+                // A vertical span from an earlier row covers this column.
+                new_cells.push(HtmlCell {
+                    colspan: 1,
+                    rowspan: 1,
+                    ..Default::default()
+                });
+                col += 1;
+                continue;
+            }
+            match next {
+                Some(cell) => {
+                    let colspan = cell.colspan.max(1);
+                    if cell.rowspan > 1 {
+                        for k in 0..colspan {
+                            new_spans.push((col + k, cell.rowspan - 1));
+                        }
+                    }
+                    let mut c = cell.clone();
+                    c.rowspan = 1;
+                    new_cells.push(c);
+                    col += colspan;
+                    next = src.next();
+                }
+                None => break,
+            }
+        }
+
+        // Every old span covered exactly this row: decrement and drop exhausted.
+        pending = pending
+            .into_iter()
+            .filter_map(|(c, n)| n.checked_sub(1).filter(|&n| n > 0).map(|n| (c, n)))
+            .collect();
+        // Now register spans started this row so they apply to following rows.
+        pending.extend(new_spans);
+
+        out.push(HtmlRow {
+            cells: new_cells,
+            is_header_row: row.is_header_row,
+        });
+    }
+    out
+}
+
+/// Authoritative grid width of an HTML table: the max over rows of summed colspan.
+fn html_grid_width(rows: &[HtmlRow]) -> usize {
+    rows.iter()
+        .map(|r| r.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Whether a row's cells exactly tile the full grid width.
+fn html_row_tiles(row: &HtmlRow, grid_width: usize) -> bool {
+    grid_width > 0 && row.cells.iter().map(|c| c.colspan.max(1)).sum::<usize>() == grid_width
+}
+
+/// The layout role of an HTML table row (mirrors the DOCX classifier).
+#[derive(Debug, Clone, PartialEq)]
+enum HtmlRowKind {
+    Banner,
+    LabelValue,
+    Tiling,
+    Fallback,
+}
+
+/// Classify a single HTML row by its cell layout. First matching rule wins.
+fn classify_html_row(row: &HtmlRow, grid_width: usize) -> HtmlRowKind {
+    let cells = &row.cells;
+    if cells.len() == 1 && grid_width >= 1 && cells[0].colspan.max(1) >= grid_width {
+        return HtmlRowKind::Banner;
+    }
+    if cells.len() == 2
+        && grid_width >= 3
+        && cells[0].colspan.max(1) == 1
+        && cells[1].colspan.max(1) == grid_width - 1
+    {
+        return HtmlRowKind::LabelValue;
+    }
+    if html_row_tiles(row, grid_width) {
+        return HtmlRowKind::Tiling;
+    }
+    HtmlRowKind::Fallback
+}
+
+/// Whether a table is "simple": uniform widths, no spans, no header/data mixing.
+///
+/// Such tables render exactly as before (first row / `<thead>` as header),
+/// guaranteeing no regression for ordinary HTML tables.
+fn html_table_is_simple(rows: &[HtmlRow]) -> bool {
+    if rows.is_empty() {
+        return true;
+    }
+    let width = rows[0].cells.len();
+    rows.iter()
+        .all(|r| r.cells.len() == width && r.cells.iter().all(|c| c.colspan <= 1 && c.rowspan <= 1))
+}
+
+/// Expand a row's cells across `grid_width` columns for GFM rendering (empty-fill).
+fn expand_html_row(row: &HtmlRow, grid_width: usize) -> Vec<String> {
+    let mut cols: Vec<String> = Vec::with_capacity(grid_width);
+    for c in &row.cells {
+        let span = c.colspan.max(1);
+        cols.push(c.content.trim().to_string());
+        for _ in 1..span {
+            cols.push(String::new());
+        }
+    }
+    cols.resize(grid_width, String::new());
+    cols
+}
+
+/// Render a contiguous run of tiling rows as one GFM table (row 0 = header).
+fn render_html_grid(rows: &[&HtmlRow], grid_width: usize, plain: bool) -> String {
+    let expanded: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| expand_html_row(r, grid_width))
+        .collect();
+    let headers: Vec<&str> = expanded[0].iter().map(|s| s.as_str()).collect();
+    let data: Vec<Vec<&str>> = expanded[1..]
+        .iter()
+        .map(|r| r.iter().map(|s| s.as_str()).collect())
+        .collect();
+    if plain {
+        markdown::build_table_plain(&headers, &data)
+    } else {
+        markdown::build_table(&headers, &data)
+    }
+}
+
 /// Render a completed table collector into a table string.
 ///
-/// When `plain` is true, produces tab-separated output; otherwise produces
-/// a pipe-delimited Markdown table.
+/// Simple tables use the historical GFM path. Spanned/layout tables are
+/// linearized: banner rows become headings/bold paragraphs, label/value rows
+/// become `**Label:** value`, contiguous tiling rows become GFM tables, and
+/// irregular rows become small standalone tables. When `plain` is true the
+/// linearized parts flatten fully and grid parts stay tab-separated.
 fn render_table(tc: &TableCollector, plain: bool) -> String {
-    // If no explicit headers (no <thead>), use first row as headers
-    let (headers, data_rows) = if tc.headers.is_empty() && !tc.rows.is_empty() {
-        (tc.rows[0].clone(), &tc.rows[1..])
-    } else {
-        (tc.headers.clone(), tc.rows.as_slice())
-    };
-
-    if headers.is_empty() {
+    let rows = normalize_html_rowspans(&tc.rows);
+    if rows.is_empty() {
+        return String::new();
+    }
+    let grid_width = html_grid_width(&rows);
+    if grid_width == 0 {
         return String::new();
     }
 
-    let header_refs: Vec<&str> = headers.iter().map(|s| s.as_str()).collect();
-    let row_refs: Vec<Vec<&str>> = data_rows
-        .iter()
-        .map(|row| row.iter().map(|s| s.as_str()).collect())
-        .collect();
-    if plain {
-        markdown::build_table_plain(&header_refs, &row_refs)
-    } else {
-        markdown::build_table(&header_refs, &row_refs)
+    // Simple table: historical behavior (header = thead row(s) or first row).
+    if html_table_is_simple(&rows) {
+        let header_idx = rows.iter().position(|r| r.is_header_row);
+        let (header_row, data): (&HtmlRow, Vec<&HtmlRow>) = match header_idx {
+            Some(i) => (&rows[i], rows.iter().filter(|r| !r.is_header_row).collect()),
+            None => (&rows[0], rows[1..].iter().collect()),
+        };
+        let headers: Vec<&str> = header_row
+            .cells
+            .iter()
+            .map(|c| c.content.as_str())
+            .collect();
+        if headers.is_empty() {
+            return String::new();
+        }
+        let data_refs: Vec<Vec<&str>> = data
+            .iter()
+            .map(|r| r.cells.iter().map(|c| c.content.as_str()).collect())
+            .collect();
+        return if plain {
+            markdown::build_table_plain(&headers, &data_refs)
+        } else {
+            markdown::build_table(&headers, &data_refs)
+        };
     }
+
+    // Hybrid path: classify each row and coalesce contiguous tiling runs.
+    let mut out = String::new();
+    let mut grid_run: Vec<&HtmlRow> = Vec::new();
+    let flush_grid = |run: &mut Vec<&HtmlRow>, out: &mut String| {
+        if !run.is_empty() {
+            out.push_str(&render_html_grid(run, grid_width, plain));
+            out.push('\n');
+            run.clear();
+        }
+    };
+
+    for row in &rows {
+        match classify_html_row(row, grid_width) {
+            HtmlRowKind::Tiling => grid_run.push(row),
+            HtmlRowKind::Banner => {
+                flush_grid(&mut grid_run, &mut out);
+                let cell = &row.cells[0];
+                let text = cell.content.trim();
+                if text.is_empty() {
+                    continue;
+                }
+                if plain {
+                    out.push_str(text);
+                    out.push_str("\n\n");
+                } else if cell.has_heading {
+                    out.push_str(&markdown::format_heading(cell.heading_level, text));
+                    out.push('\n');
+                } else {
+                    out.push_str(&format!("**{text}**\n\n"));
+                }
+            }
+            HtmlRowKind::LabelValue => {
+                flush_grid(&mut grid_run, &mut out);
+                let label = row.cells[0].content.trim().trim_end_matches(':');
+                let value = row.cells[1].content.trim();
+                if plain {
+                    out.push_str(label);
+                    out.push('\n');
+                    if !value.is_empty() {
+                        out.push_str(value);
+                        out.push('\n');
+                    }
+                    out.push('\n');
+                } else {
+                    out.push_str(&format!("**{label}:** {value}\n\n"));
+                }
+            }
+            HtmlRowKind::Fallback => {
+                flush_grid(&mut grid_run, &mut out);
+                let texts: Vec<&str> = row.cells.iter().map(|c| c.content.as_str()).collect();
+                if plain {
+                    out.push_str(&markdown::build_table_plain(&texts, &[]));
+                } else {
+                    out.push_str(&markdown::build_table(&texts, &[]));
+                }
+                out.push('\n');
+            }
+        }
+    }
+    flush_grid(&mut grid_run, &mut out);
+    out
 }
 
 #[cfg(test)]
@@ -882,6 +1182,154 @@ mod tests {
         </table>"#;
         let result = convert_html(html);
         assert!(result.markdown.contains("| 1 |  | 3 |"));
+    }
+
+    #[test]
+    fn test_html_table_colspan_preserved() {
+        // A full-width colspan banner over a 2-column data grid. Both data
+        // columns must survive (previously only the first was kept).
+        let html = r#"<table>
+            <tr><td colspan="2">Banner</td></tr>
+            <tr><td>A</td><td>B</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        assert!(result.markdown.contains("A"), "md: {}", result.markdown);
+        assert!(result.markdown.contains("B"), "md: {}", result.markdown);
+        assert!(
+            result.markdown.contains("| A | B |"),
+            "both columns missing: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_table_banner_bold() {
+        let html = r#"<table>
+            <tr><td colspan="3">Section</td></tr>
+            <tr><td>a</td><td>b</td><td>c</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("**Section**"),
+            "md: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_table_banner_heading() {
+        let html = r#"<table>
+            <tr><td colspan="3"><h2>Section</h2></td></tr>
+            <tr><td>a</td><td>b</td><td>c</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("## Section"),
+            "md: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_table_label_value() {
+        let html = r#"<table>
+            <tr><td>Date</td><td colspan="2">Monday</td></tr>
+            <tr><td>a</td><td>b</td><td>c</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        assert!(
+            result.markdown.contains("**Date:** Monday"),
+            "md: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_table_rowspan_preserved() {
+        // rowspan on the first column: the second data row's other columns must
+        // not shift left into the spanned column.
+        let html = r#"<table>
+            <tr><td rowspan="2">Merged</td><td>X1</td><td>Y1</td></tr>
+            <tr><td>X2</td><td>Y2</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        for needle in ["Merged", "X1", "Y1", "X2", "Y2"] {
+            assert!(
+                result.markdown.contains(needle),
+                "missing {needle}: {}",
+                result.markdown
+            );
+        }
+        // Second row: spanned column is empty, X2/Y2 stay in columns 2 and 3.
+        assert!(
+            result.markdown.contains("|  | X2 | Y2 |"),
+            "rowspan column not preserved: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn test_html_nested_table() {
+        let html = r#"<table>
+            <tr><td colspan="2">Outer</td></tr>
+            <tr><td>cell<table><tr><td>inner1</td><td>inner2</td></tr></table></td><td>right</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        for needle in ["Outer", "inner1", "inner2", "right"] {
+            assert!(
+                result.markdown.contains(needle),
+                "missing {needle}: {}",
+                result.markdown
+            );
+        }
+    }
+
+    #[test]
+    fn test_html_plain_linearized_flattened() {
+        let html = r#"<table>
+            <tr><td colspan="3">Section</td></tr>
+            <tr><td>Field</td><td colspan="2">Value</td></tr>
+            <tr><td>A</td><td>B</td><td>C</td></tr>
+        </table>"#;
+        let result = convert_html(html);
+        // Plain text: no markdown markers in linearized parts.
+        assert!(
+            result.plain_text.contains("Section"),
+            "plain: {}",
+            result.plain_text
+        );
+        assert!(
+            result.plain_text.contains("Field"),
+            "plain: {}",
+            result.plain_text
+        );
+        assert!(
+            result.plain_text.contains("Value"),
+            "plain: {}",
+            result.plain_text
+        );
+        assert!(
+            !result.plain_text.contains("**"),
+            "plain has markers: {}",
+            result.plain_text
+        );
+        // Grid region tab-separated.
+        assert!(
+            result.plain_text.contains("A\tB\tC"),
+            "plain grid not tabbed: {}",
+            result.plain_text
+        );
+    }
+
+    #[test]
+    fn test_html_simple_table_unchanged_deterministic() {
+        // A simple uniform table must use the historical GFM path and be stable.
+        let html = r#"<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"#;
+        let r1 = convert_html(html);
+        let r2 = convert_html(html);
+        assert_eq!(r1.markdown, r2.markdown);
+        assert!(r1.markdown.contains("| a | b |"));
+        assert!(r1.markdown.contains("| c | d |"));
     }
 
     #[test]

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -322,6 +322,11 @@ fn parse_slide(xml: &str) -> (Vec<ShapeContent>, Vec<ConversionWarning>) {
                         "tc" if in_table_cell => {
                             // Merge-continuation placeholders render empty so the
                             // spanning cell's text is not duplicated across columns.
+                            // (PowerPoint echoes the spanning cell's text into the
+                            // hMerge/vMerge placeholder, so blanking it is what
+                            // dedups; this is preferred over recovering the rare
+                            // orphan-with-text case, which cannot be distinguished
+                            // from that echo by text presence alone.)
                             if current_cell_is_merge {
                                 current_row.push(String::new());
                             } else {

--- a/src/converter/pptx.rs
+++ b/src/converter/pptx.rs
@@ -145,6 +145,10 @@ fn parse_slide(xml: &str) -> (Vec<ShapeContent>, Vec<ConversionWarning>) {
     let mut table_rows: Vec<Vec<String>> = Vec::new();
     let mut current_row: Vec<String> = Vec::new();
     let mut current_cell = String::new();
+    // True when the current `<a:tc>` is a horizontal/vertical merge continuation
+    // (an `hMerge`/`vMerge` placeholder covered by a spanning cell). Its content
+    // belongs to the spanning cell, so the placeholder is emitted empty.
+    let mut current_cell_is_merge = false;
     // Track text state within table cells
     let mut in_cell_paragraph = false;
     let mut in_cell_run = false;
@@ -207,9 +211,11 @@ fn parse_slide(xml: &str) -> (Vec<ShapeContent>, Vec<ConversionWarning>) {
                         graphic_frame_depth += 1;
                         handle_graphic_frame_start(
                             local_str,
+                            e,
                             &mut in_table,
                             &mut in_table_row,
                             &mut in_table_cell,
+                            &mut current_cell_is_merge,
                             &mut in_cell_paragraph,
                             &mut in_cell_run,
                             &mut in_cell_text,
@@ -314,8 +320,15 @@ fn parse_slide(xml: &str) -> (Vec<ShapeContent>, Vec<ConversionWarning>) {
                             in_cell_paragraph = false;
                         }
                         "tc" if in_table_cell => {
-                            current_row.push(current_cell.trim().to_string());
+                            // Merge-continuation placeholders render empty so the
+                            // spanning cell's text is not duplicated across columns.
+                            if current_cell_is_merge {
+                                current_row.push(String::new());
+                            } else {
+                                current_row.push(current_cell.trim().to_string());
+                            }
                             current_cell.clear();
+                            current_cell_is_merge = false;
                             in_table_cell = false;
                             in_cell_paragraph = false;
                             in_cell_run = false;
@@ -475,9 +488,11 @@ fn handle_shape_empty(
 #[allow(clippy::too_many_arguments)]
 fn handle_graphic_frame_start(
     local_str: &str,
+    e: &quick_xml::events::BytesStart,
     in_table: &mut bool,
     in_table_row: &mut bool,
     in_table_cell: &mut bool,
+    current_cell_is_merge: &mut bool,
     in_cell_paragraph: &mut bool,
     in_cell_run: &mut bool,
     in_cell_text: &mut bool,
@@ -497,6 +512,14 @@ fn handle_graphic_frame_start(
         "tc" if *in_table_row => {
             *in_table_cell = true;
             current_cell.clear();
+            // A cell carrying `hMerge`/`vMerge` is a placeholder covered by a
+            // spanning cell; its visible text (if any) belongs to that cell.
+            let is_merge = |name| {
+                attr_value_unescaped(e, name)
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false)
+            };
+            *current_cell_is_merge = is_merge("hMerge") || is_merge("vMerge");
         }
         "p" if *in_table_cell => {
             // Add space separator between paragraphs in the same cell
@@ -1778,6 +1801,42 @@ mod tests {
             .unwrap();
         assert!(result.markdown.contains("| A | B | C |"));
         assert!(result.markdown.contains("| 1 |  | 3 |"));
+    }
+
+    #[test]
+    fn test_pptx_table_hmerge_cell_empty() {
+        // A horizontal merge: the spanning cell carries the text and the covered
+        // placeholder cell (`hMerge="1"`) renders empty, not duplicated.
+        let slide_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="3" name="Table"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr><a:graphic><a:graphicData><a:tbl><a:tr><a:tc gridSpan="2"><a:txBody><a:p><a:r><a:t>Span</a:t></a:r></a:p></a:txBody></a:tc><a:tc hMerge="1"><a:txBody><a:p><a:r><a:t>Span</a:t></a:r></a:p></a:txBody></a:tc></a:tr><a:tr><a:tc><a:txBody><a:p><a:r><a:t>A</a:t></a:r></a:p></a:txBody></a:tc><a:tc><a:txBody><a:p><a:r><a:t>B</a:t></a:r></a:p></a:txBody></a:tc></a:tr></a:tbl></a:graphicData></a:graphic></p:graphicFrame></p:spTree></p:cSld></p:sld>"#;
+        let (shapes, _) = parse_slide(slide_xml);
+        let table = shapes
+            .iter()
+            .find_map(|s| match s {
+                ShapeContent::Table { headers, rows } => Some((headers, rows)),
+                _ => None,
+            })
+            .expect("table shape");
+        // Header row: spanning cell text in column 1, placeholder empty in column 2.
+        assert_eq!(table.0, &vec!["Span".to_string(), String::new()]);
+        // Data row still has both columns.
+        assert_eq!(table.1[0], vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn test_pptx_table_gridspan_keeps_columns() {
+        // A gridSpan cell keeps its text; the column count stays correct because
+        // DrawingML emits an hMerge placeholder for the covered column.
+        let slide_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="3" name="Table"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr><a:graphic><a:graphicData><a:tbl><a:tr><a:tc><a:txBody><a:p><a:r><a:t>H1</a:t></a:r></a:p></a:txBody></a:tc><a:tc><a:txBody><a:p><a:r><a:t>H2</a:t></a:r></a:p></a:txBody></a:tc></a:tr><a:tr><a:tc gridSpan="2"><a:txBody><a:p><a:r><a:t>Wide</a:t></a:r></a:p></a:txBody></a:tc><a:tc hMerge="1"><a:txBody><a:p/></a:txBody></a:tc></a:tr></a:tbl></a:graphicData></a:graphic></p:graphicFrame></p:spTree></p:cSld></p:sld>"#;
+        let (shapes, _) = parse_slide(slide_xml);
+        let rows = shapes
+            .iter()
+            .find_map(|s| match s {
+                ShapeContent::Table { rows, .. } => Some(rows),
+                _ => None,
+            })
+            .expect("table shape");
+        // Header row keeps both columns; data row keeps "Wide" then empty placeholder.
+        assert_eq!(rows[0], vec!["Wide".to_string(), String::new()]);
     }
 
     #[test]

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -6,6 +6,10 @@
 
 /// Escape special characters in a table cell so that pipes, backslashes,
 /// and newlines do not break Markdown table structure.
+///
+/// Converters that build grid regions from multi-paragraph cells join those
+/// paragraphs with `\n` before calling [`build_table`], so the newline-to-`<br>`
+/// collapse here is what keeps such a cell on a single Markdown table row.
 fn escape_cell(content: &str) -> String {
     content
         .replace('\\', "\\\\")

--- a/tests/fixtures/expected/layout_table.docx.md
+++ b/tests/fixtures/expected/layout_table.docx.md
@@ -1,0 +1,7 @@
+## Section Title
+
+**Field:** Value
+
+| Info | Col A | Col B | Col C |
+|---|---|---|---|
+|  | 1 | 2 | 3 |

--- a/tests/fixtures/expected/layout_table.docx.md
+++ b/tests/fixtures/expected/layout_table.docx.md
@@ -1,7 +1,5 @@
-## Section Title
-
-**Field:** Value
-
-| Info | Col A | Col B | Col C |
+| Section Title |  |  |  |
 |---|---|---|---|
+| Field | Value |  |  |
+| Info | Col A | Col B | Col C |
 |  | 1 | 2 | 3 |

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -485,3 +485,102 @@ fn test_docx_layout_table_golden() {
     let expected = include_str!("fixtures/expected/layout_table.docx.md");
     assert_eq!(normalize(&result.markdown), normalize(expected));
 }
+
+/// Regression (review finding): a long-form `<w:gridSpan></w:gridSpan>` (not
+/// self-closing) must still be parsed, so a full-width banner linearizes rather
+/// than collapsing the table to one column.
+#[test]
+fn test_docx_long_form_gridspan_parsed() {
+    let body = concat!(
+        r#"<w:tbl><w:tblGrid><w:gridCol w:w="1"/><w:gridCol w:w="1"/></w:tblGrid>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="2"></w:gridSpan></w:tcPr><w:p><w:r><w:t>Banner</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.contains("**Banner**"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("| A | B |"),
+        "md: {}",
+        result.markdown
+    );
+}
+
+/// Regression (review finding): an orphan vMerge continuation cell that carries
+/// text (no matching restart) must not silently drop its content.
+#[test]
+fn test_docx_orphan_vmerge_preserves_text() {
+    let body = concat!(
+        r#"<w:tbl><w:tblGrid><w:gridCol w:w="1"/><w:gridCol w:w="1"/></w:tblGrid>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p><w:r><w:t>OrphanText</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>sib</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>y</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.contains("OrphanText"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        result.plain_text.contains("OrphanText"),
+        "plain: {}",
+        result.plain_text
+    );
+}
+
+/// Regression (review finding): a table inside a text box inside a table cell must
+/// not scramble document order. The outer cell text and the inner table both
+/// appear, and the inner table is not emitted ahead of the surrounding content.
+#[test]
+fn test_docx_textbox_table_in_cell_no_reorder() {
+    let body = concat!(
+        r#"<w:tbl><w:tblGrid><w:gridCol w:w="1"/></w:tblGrid><w:tr><w:tc>"#,
+        r#"<w:p><w:r><w:t>outer-before</w:t></w:r>"#,
+        r#"<w:r><w:pict><v:shape><v:textbox><w:txbxContent>"#,
+        r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner-cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#,
+        r#"</w:txbxContent></v:textbox></v:shape></w:pict></w:r>"#,
+        r#"<w:r><w:t>outer-after</w:t></w:r></w:p>"#,
+        r#"</w:tc></w:tr></w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    // All content present.
+    for needle in ["outer-before", "inner-cell", "outer-after"] {
+        assert!(
+            result.markdown.contains(needle),
+            "missing {needle}: {}",
+            result.markdown
+        );
+    }
+    // The outer paragraph text is kept together (not split around the inner table).
+    assert!(
+        result.markdown.contains("outer-before") && result.markdown.contains("outer-after"),
+        "md: {}",
+        result.markdown
+    );
+}
+
+/// Regression (review finding): a huge gridSpan must not drive unbounded
+/// allocation; conversion completes quickly with bounded output.
+#[test]
+fn test_docx_huge_gridspan_bounded() {
+    let body = concat!(
+        r#"<w:tbl>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="1000000"/></w:tcPr><w:p><w:r><w:t>X</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Y</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="1000000"/></w:tcPr><w:p><w:r><w:t>P</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Q</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    // Bounded output (not megabytes of empty pipes).
+    assert!(
+        result.markdown.len() < 100_000,
+        "output not bounded: {} bytes",
+        result.markdown.len()
+    );
+    assert!(result.markdown.contains('X'));
+}

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -395,7 +395,7 @@ fn build_docx_from_body(body: &str, styles_xml: Option<&str>) -> Vec<u8> {
     zip.finish().unwrap().into_inner()
 }
 
-/// End-to-end test for a merged/layout table converted via the hybrid path.
+/// End-to-end test for a merged/layout table.
 ///
 /// The synthetic document mirrors the structure of a layout table that uses
 /// `gridSpan`/`vMerge` for sectioning rather than tabular data: a full-width,
@@ -403,10 +403,10 @@ fn build_docx_from_body(body: &str, styles_xml: Option<&str>) -> Vec<u8> {
 /// two-row data grid with a vertically merged label column, plus an
 /// authoritative `<w:tblGrid>` declaring four columns.
 ///
-/// The previous converter collapsed all of this to a single column; the hybrid
-/// renderer must preserve every column and linearize the layout rows.
+/// The previous converter collapsed all of this to a single column; the converter
+/// must preserve every column by rendering it as one empty-filled GFM grid.
 #[test]
-fn test_docx_layout_table_hybrid_integration() {
+fn test_docx_layout_table_grid_integration() {
     let styles = r#"<?xml version="1.0" encoding="UTF-8"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/></w:style></w:styles>"#;
 
     // 4-column grid. Rows: banner (span4, Heading2), label/value (1 + span3),
@@ -428,27 +428,20 @@ fn test_docx_layout_table_hybrid_integration() {
     let data = build_docx_from_body(body, Some(styles));
     let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
 
-    // Banner row → heading.
+    // The whole table is one empty-filled GFM grid; every row keeps all columns.
     assert!(
-        result.markdown.contains("## Section Title"),
-        "banner not promoted to heading: {}",
+        result.markdown.contains("| Section Title |  |  |  |"),
+        "banner not an empty-filled header row: {}",
         result.markdown
     );
-    // Label/value row → bold label + value.
     assert!(
-        result.markdown.contains("**Field:** Value"),
-        "label/value not linearized: {}",
+        result.markdown.contains("| Field | Value |  |  |"),
+        "label/value not a grid row: {}",
         result.markdown
     );
-    // Data grid → all columns preserved.
     assert!(
         result.markdown.contains("| Info | Col A | Col B | Col C |"),
         "grid header columns missing: {}",
-        result.markdown
-    );
-    assert!(
-        result.markdown.contains("| 2 | 3 |"),
-        "grid data columns missing: {}",
         result.markdown
     );
     // The vMerge continuation cell is empty in the data row.
@@ -457,10 +450,12 @@ fn test_docx_layout_table_hybrid_integration() {
         "vMerge continuation not empty: {}",
         result.markdown
     );
+    // No heading/bold linearization.
+    assert!(!result.markdown.contains('#'), "md: {}", result.markdown);
+    assert!(!result.markdown.contains("**"), "md: {}", result.markdown);
 
-    // Plain text linearizes without markdown markers but keeps grid tabs.
+    // Plain text is tab-separated, no markdown markers.
     assert!(result.plain_text.contains("Section Title"));
-    assert!(result.plain_text.contains("Field"));
     assert!(!result.plain_text.contains("**"));
     assert!(result.plain_text.contains("Col A\tCol B\tCol C"));
 }
@@ -487,8 +482,8 @@ fn test_docx_layout_table_golden() {
 }
 
 /// Regression (review finding): a long-form `<w:gridSpan></w:gridSpan>` (not
-/// self-closing) must still be parsed, so a full-width banner linearizes rather
-/// than collapsing the table to one column.
+/// self-closing) must still be parsed, so the full-width banner spans the grid
+/// (empty-filled) rather than collapsing the table to one column.
 #[test]
 fn test_docx_long_form_gridspan_parsed() {
     let body = concat!(
@@ -498,9 +493,10 @@ fn test_docx_long_form_gridspan_parsed() {
     );
     let data = build_docx_from_body(body, None);
     let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    // Banner is the header row, empty-filled to the full grid width.
     assert!(
-        result.markdown.contains("**Banner**"),
-        "md: {}",
+        result.markdown.contains("| Banner |  |"),
+        "long-form gridSpan not parsed: {}",
         result.markdown
     );
     assert!(
@@ -533,11 +529,17 @@ fn test_docx_orphan_vmerge_preserves_text() {
     );
 }
 
-/// Regression (review finding): a table inside a text box inside a table cell must
-/// not scramble document order. The outer cell text and the inner table both
-/// appear, and the inner table is not emitted ahead of the surrounding content.
+/// A table inside a text box inside a table cell: all content must survive
+/// (no data loss), which is the property that matters for extraction.
+///
+/// Known limitation: a text box is a separate content flow, and because the
+/// enclosing table is buffered and rendered at its end tag, the text box's inner
+/// table is emitted to the document before the enclosing table. Document order is
+/// therefore not preserved for this (rare, arguably malformed) nesting. This test
+/// asserts content survival and pins the current ordering so a future ordering
+/// fix is a deliberate, visible change rather than an accident.
 #[test]
-fn test_docx_textbox_table_in_cell_no_reorder() {
+fn test_docx_textbox_table_in_cell_content_survives() {
     let body = concat!(
         r#"<w:tbl><w:tblGrid><w:gridCol w:w="1"/></w:tblGrid><w:tr><w:tc>"#,
         r#"<w:p><w:r><w:t>outer-before</w:t></w:r>"#,
@@ -549,7 +551,7 @@ fn test_docx_textbox_table_in_cell_no_reorder() {
     );
     let data = build_docx_from_body(body, None);
     let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
-    // All content present.
+    // No data loss: all three pieces of content are present.
     for needle in ["outer-before", "inner-cell", "outer-after"] {
         assert!(
             result.markdown.contains(needle),
@@ -557,10 +559,15 @@ fn test_docx_textbox_table_in_cell_no_reorder() {
             result.markdown
         );
     }
-    // The outer paragraph text is kept together (not split around the inner table).
+    // The text-box content does NOT leak into the enclosing cell (it renders to
+    // the document, not inside the outer cell's row).
+    let inner = result.markdown.find("inner-cell").unwrap();
+    let outer = result.markdown.find("outer-before").unwrap();
+    // Known-order limitation: the text box's table currently precedes the
+    // enclosing table. Pinned so a future fix is intentional.
     assert!(
-        result.markdown.contains("outer-before") && result.markdown.contains("outer-after"),
-        "md: {}",
+        inner < outer,
+        "ordering changed (a fix?): {}",
         result.markdown
     );
 }

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -506,6 +506,25 @@ fn test_docx_long_form_gridspan_parsed() {
     );
 }
 
+/// Regression (review finding): a row with more cells than the declared
+/// `<w:tblGrid>` width must keep every cell. The grid count is a floor, not a
+/// ceiling, so trailing cells are no longer silently dropped.
+#[test]
+fn test_docx_row_wider_than_tblgrid_keeps_all_cells() {
+    let body = concat!(
+        r#"<w:tbl><w:tblGrid><w:gridCol w:w="1"/><w:gridCol w:w="1"/></w:tblGrid>"#,
+        r#"<w:tr><w:tc><w:p><w:r><w:t>H1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>H2</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>B</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>C</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.contains("| A | B | C |"),
+        "trailing cell dropped: {}",
+        result.markdown
+    );
+}
+
 /// Regression (review finding): an orphan vMerge continuation cell that carries
 /// text (no matching restart) must not silently drop its content.
 #[test]
@@ -590,4 +609,92 @@ fn test_docx_huge_gridspan_bounded() {
         result.markdown.len()
     );
     assert!(result.markdown.contains('X'));
+}
+
+/// DoS guard (review finding): a table with more rows than the cell cap allows
+/// is truncated, and the dropped rows are observable via a ResourceLimitReached
+/// warning (best-effort: never silently drop content).
+#[test]
+fn test_docx_table_rows_capped_with_warning() {
+    use anytomd::WarningCode;
+
+    // Wide grid (1000 cols) ⇒ max_rows = MAX_TABLE_CELLS / 1000 = 100. Emit more
+    // than that so truncation triggers without building a huge document.
+    let cols = "<w:gridCol w:w=\"1\"/>".repeat(1000);
+    let mut body = format!("<w:tbl><w:tblGrid>{cols}</w:tblGrid>");
+    // 150 rows, each a single full-width gridSpan banner (one cell per row).
+    for i in 0..150 {
+        body.push_str(&format!(
+            r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="1000"/></w:tcPr><w:p><w:r><w:t>row{i}</w:t></w:r></w:p></w:tc></w:tr>"#
+        ));
+    }
+    body.push_str("</w:tbl>");
+
+    let data = build_docx_from_body(&body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+
+    // Truncated: an early row survives, a late row (beyond max_rows=100) does not.
+    assert!(result.markdown.contains("row0"), "early row missing");
+    assert!(
+        !result.markdown.contains("row149"),
+        "table not truncated: {}",
+        result.markdown.len()
+    );
+    // Dropping rows is observable.
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::ResourceLimitReached),
+        "expected ResourceLimitReached warning, got: {:?}",
+        result.warnings
+    );
+}
+
+/// Regression (review finding): a table that contains a nested table, followed
+/// by a paragraph, must have exactly one blank line between them — the same
+/// spacing as a normal table and the HTML linearize path (no extra blank line).
+#[test]
+fn test_docx_nested_table_one_blank_line_before_following_paragraph() {
+    let inner =
+        r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"#;
+    let body = format!(
+        concat!(
+            r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>before</w:t></w:r></w:p>{inner}</w:tc></w:tr></w:tbl>"#,
+            r#"<w:p><w:r><w:t>After paragraph.</w:t></w:r></w:p>"#,
+        ),
+        inner = inner
+    );
+    let data = build_docx_from_body(&body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+
+    // The inner one-column table renders as `| inner |` / `|---|` (header +
+    // separator, no data rows). Assert the following paragraph is separated from
+    // the table's last line (`|---|`) by exactly one blank line (\n\n), not two.
+    let md = &result.markdown;
+    let after_idx = md.find("After paragraph.").expect("paragraph missing");
+    let before = &md[..after_idx];
+    assert!(before.contains("| inner |"), "inner table missing: {md}");
+    assert!(
+        before.ends_with("|---|\n\n"),
+        "expected exactly one blank line before the paragraph, before={before:?}"
+    );
+    assert!(
+        !before.ends_with("|---|\n\n\n"),
+        "extra blank line after nested-table table, before={before:?}"
+    );
+
+    // Plain stream: exactly one blank line as well.
+    let p = &result.plain_text;
+    let pa = p.find("After paragraph.").expect("plain paragraph missing");
+    assert!(
+        p[..pa].ends_with("inner\n\n"),
+        "expected one blank line in plain, was:\n{:?}",
+        &p[..pa]
+    );
+    assert!(
+        !p[..pa].ends_with("inner\n\n\n"),
+        "extra blank line in plain, was:\n{:?}",
+        &p[..pa]
+    );
 }

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -358,3 +358,130 @@ fn test_docx_extract_comments_end_to_end() {
     assert!(result.plain_text.contains("source: next Friday"));
     assert!(!result.plain_text.contains("# Comments"));
 }
+
+/// Build a minimal DOCX in memory from a document.xml body and optional styles.
+fn build_docx_from_body(body: &str, styles_xml: Option<&str>) -> Vec<u8> {
+    use std::io::Write;
+    use zip::ZipWriter;
+    use zip::write::SimpleFileOptions;
+
+    let buf = Vec::new();
+    let mut zip = ZipWriter::new(Cursor::new(buf));
+    let opts = SimpleFileOptions::default();
+
+    zip.start_file("[Content_Types].xml", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+    )
+    .unwrap();
+
+    zip.start_file("_rels/.rels", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+    )
+    .unwrap();
+
+    let document_xml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{body}</w:body></w:document>"#
+    );
+    zip.start_file("word/document.xml", opts).unwrap();
+    zip.write_all(document_xml.as_bytes()).unwrap();
+
+    if let Some(styles) = styles_xml {
+        zip.start_file("word/styles.xml", opts).unwrap();
+        zip.write_all(styles.as_bytes()).unwrap();
+    }
+
+    zip.finish().unwrap().into_inner()
+}
+
+/// End-to-end test for a merged/layout table converted via the hybrid path.
+///
+/// The synthetic document mirrors the structure of a layout table that uses
+/// `gridSpan`/`vMerge` for sectioning rather than tabular data: a full-width,
+/// heading-styled banner row; a narrow-label + wide-spanning-value row; and a
+/// two-row data grid with a vertically merged label column, plus an
+/// authoritative `<w:tblGrid>` declaring four columns.
+///
+/// The previous converter collapsed all of this to a single column; the hybrid
+/// renderer must preserve every column and linearize the layout rows.
+#[test]
+fn test_docx_layout_table_hybrid_integration() {
+    let styles = r#"<?xml version="1.0" encoding="UTF-8"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/></w:style></w:styles>"#;
+
+    // 4-column grid. Rows: banner (span4, Heading2), label/value (1 + span3),
+    // data grid header (vMerge restart label + 3 cols), data row (vMerge continue + 3 cols).
+    let body = concat!(
+        r#"<w:tbl>"#,
+        r#"<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>"#,
+        // Banner row, heading-styled
+        r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="4"/></w:tcPr><w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Section Title</w:t></w:r></w:p></w:tc></w:tr>"#,
+        // Label/value row
+        r#"<w:tr><w:tc><w:p><w:r><w:t>Field</w:t></w:r></w:p></w:tc><w:tc><w:tcPr><w:gridSpan w:val="3"/></w:tcPr><w:p><w:r><w:t>Value</w:t></w:r></w:p></w:tc></w:tr>"#,
+        // Data grid header: vMerge restart label + 3 data columns
+        r#"<w:tr><w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Info</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col B</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col C</w:t></w:r></w:p></w:tc></w:tr>"#,
+        // Data row: vMerge continue + 3 values
+        r#"<w:tr><w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc><w:tc><w:p><w:r><w:t>1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>2</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>3</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"</w:tbl>"#,
+    );
+
+    let data = build_docx_from_body(body, Some(styles));
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+
+    // Banner row → heading.
+    assert!(
+        result.markdown.contains("## Section Title"),
+        "banner not promoted to heading: {}",
+        result.markdown
+    );
+    // Label/value row → bold label + value.
+    assert!(
+        result.markdown.contains("**Field:** Value"),
+        "label/value not linearized: {}",
+        result.markdown
+    );
+    // Data grid → all columns preserved.
+    assert!(
+        result.markdown.contains("| Info | Col A | Col B | Col C |"),
+        "grid header columns missing: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("| 2 | 3 |"),
+        "grid data columns missing: {}",
+        result.markdown
+    );
+    // The vMerge continuation cell is empty in the data row.
+    assert!(
+        result.markdown.contains("|  | 1 | 2 | 3 |"),
+        "vMerge continuation not empty: {}",
+        result.markdown
+    );
+
+    // Plain text linearizes without markdown markers but keeps grid tabs.
+    assert!(result.plain_text.contains("Section Title"));
+    assert!(result.plain_text.contains("Field"));
+    assert!(!result.plain_text.contains("**"));
+    assert!(result.plain_text.contains("Col A\tCol B\tCol C"));
+}
+
+/// Golden test: the merged/layout table renders to a stable, fully-preserved
+/// Markdown layout. Update the expected file with a documented reason if the
+/// hybrid rendering intentionally changes.
+#[test]
+fn test_docx_layout_table_golden() {
+    let styles = r#"<?xml version="1.0" encoding="UTF-8"?><w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/></w:style></w:styles>"#;
+    let body = concat!(
+        r#"<w:tbl>"#,
+        r#"<w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="4"/></w:tcPr><w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Section Title</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:p><w:r><w:t>Field</w:t></w:r></w:p></w:tc><w:tc><w:tcPr><w:gridSpan w:val="3"/></w:tcPr><w:p><w:r><w:t>Value</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>Info</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col A</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col B</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>Col C</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"<w:tr><w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc><w:tc><w:p><w:r><w:t>1</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>2</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>3</w:t></w:r></w:p></w:tc></w:tr>"#,
+        r#"</w:tbl>"#,
+    );
+    let data = build_docx_from_body(body, Some(styles));
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+    let expected = include_str!("fixtures/expected/layout_table.docx.md");
+    assert_eq!(normalize(&result.markdown), normalize(expected));
+}

--- a/tests/test_docx.rs
+++ b/tests/test_docx.rs
@@ -651,6 +651,76 @@ fn test_docx_table_rows_capped_with_warning() {
     );
 }
 
+/// Regression (review finding): a content-empty nested table is suppressed
+/// entirely, so it must not surface a ResourceLimitReached truncation warning —
+/// a warning without any visible output would be a false positive (nothing
+/// observable was dropped).
+#[test]
+fn test_docx_suppressed_empty_nested_table_emits_no_truncation_warning() {
+    use anytomd::WarningCode;
+
+    // Inner table: wide grid (1000 cols) ⇒ max_rows = MAX_TABLE_CELLS / 1000 =
+    // 100; 150 all-empty rows would trip the row cap, but every cell is blank so
+    // the whole inner table is suppressed and nothing visible is dropped.
+    let cols = "<w:gridCol w:w=\"1\"/>".repeat(1000);
+    let mut inner = format!("<w:tbl><w:tblGrid>{cols}</w:tblGrid>");
+    for _ in 0..150 {
+        inner.push_str(
+            r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="1000"/></w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+    }
+    inner.push_str("</w:tbl>");
+    let body = format!(
+        r#"<w:tbl><w:tr><w:tc><w:p><w:r><w:t>OUT</w:t></w:r></w:p>{inner}</w:tc></w:tr></w:tbl>"#
+    );
+
+    let data = build_docx_from_body(&body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+
+    assert!(result.markdown.contains("OUT"), "outer cell text missing");
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::ResourceLimitReached),
+        "false-positive truncation warning for a fully suppressed table: {:?}",
+        result.warnings
+    );
+}
+
+/// Regression (review finding): an all-blank outer table over the row cap is
+/// discarded (no output), so it must not surface a truncation warning either.
+#[test]
+fn test_docx_all_blank_overlimit_table_emits_no_warning_and_no_output() {
+    use anytomd::WarningCode;
+
+    let cols = "<w:gridCol w:w=\"1\"/>".repeat(1000);
+    let mut body = format!("<w:tbl><w:tblGrid>{cols}</w:tblGrid>");
+    for _ in 0..150 {
+        body.push_str(
+            r#"<w:tr><w:tc><w:tcPr><w:gridSpan w:val="1000"/></w:tcPr><w:p/></w:tc></w:tr>"#,
+        );
+    }
+    body.push_str("</w:tbl>");
+
+    let data = build_docx_from_body(&body, None);
+    let result = anytomd::convert_bytes(&data, "docx", &ConversionOptions::default()).unwrap();
+
+    assert!(
+        !result.markdown.contains('|'),
+        "all-blank table should be discarded, got: {}",
+        result.markdown
+    );
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::ResourceLimitReached),
+        "false-positive truncation warning for a discarded table: {:?}",
+        result.warnings
+    );
+}
+
 /// Regression (review finding): a table that contains a nested table, followed
 /// by a paragraph, must have exactly one blank line between them — the same
 /// spacing as a normal table and the HTML linearize path (no extra blank line).

--- a/tests/test_html.rs
+++ b/tests/test_html.rs
@@ -210,3 +210,34 @@ fn test_html_data_table_spanning_row_keeps_columns() {
         result.markdown
     );
 }
+
+/// Regression (best-effort-observable): an over-large table must surface a
+/// ResourceLimitReached warning through the public API rather than truncating
+/// silently.
+#[test]
+fn test_html_oversized_table_warns_end_to_end() {
+    use anytomd::WarningCode;
+    let cols = 1000usize;
+    let rows = 200usize; // 200_000 cells > MAX_TABLE_CELLS
+    let mut html = String::from("<html><body><table>");
+    for _ in 0..rows {
+        html.push_str("<tr>");
+        for c in 0..cols {
+            html.push_str("<td>");
+            html.push_str(&c.to_string());
+            html.push_str("</td>");
+        }
+        html.push_str("</tr>");
+    }
+    html.push_str("</table></body></html>");
+    let result =
+        anytomd::convert_bytes(html.as_bytes(), "html", &ConversionOptions::default()).unwrap();
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code == WarningCode::ResourceLimitReached),
+        "no truncation warning surfaced: {:?}",
+        result.warnings
+    );
+}

--- a/tests/test_html.rs
+++ b/tests/test_html.rs
@@ -99,13 +99,13 @@ fn test_html_convert_bytes_direct() {
     assert!(result.markdown.contains("World"));
 }
 
-/// Integration test: a colspan/rowspan layout table converts via the hybrid path.
+/// Integration test: a colspan/rowspan layout table renders as one GFM grid.
 ///
 /// Mirrors the structure of a layout table (full-width banner, label/value rows,
 /// and a data grid) that previously collapsed to a single column. All columns
-/// must survive and the layout rows must linearize.
+/// must survive as one empty-filled grid (no heading / `**Label:**` promotion).
 #[test]
-fn test_html_colspan_layout_hybrid() {
+fn test_html_colspan_layout_grid() {
     let input = br#"<html><body><table>
         <tr><td colspan="3"><h2>Section Title</h2></td></tr>
         <tr><td>Field</td><td colspan="2">Value</td></tr>
@@ -115,13 +115,13 @@ fn test_html_colspan_layout_hybrid() {
     let result = anytomd::convert_bytes(input, "html", &ConversionOptions::default()).unwrap();
 
     assert!(
-        result.markdown.contains("## Section Title"),
-        "banner not a heading: {}",
+        result.markdown.contains("| Section Title |  |  |"),
+        "banner not an empty-filled header: {}",
         result.markdown
     );
     assert!(
-        result.markdown.contains("**Field:** Value"),
-        "label/value not linearized: {}",
+        result.markdown.contains("| Field | Value |  |"),
+        "label/value not a grid row: {}",
         result.markdown
     );
     assert!(
@@ -132,6 +132,17 @@ fn test_html_colspan_layout_hybrid() {
     assert!(
         result.markdown.contains("| 1 | 2 | 3 |"),
         "grid data missing: {}",
+        result.markdown
+    );
+    // No heading / bold linearization.
+    assert!(
+        !result.markdown.contains("## Section"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        !result.markdown.contains("**Field:**"),
+        "md: {}",
         result.markdown
     );
 }
@@ -170,5 +181,32 @@ fn test_html_colspan_dos_bounded_end_to_end() {
         result.markdown.len() < 100_000,
         "not bounded: {} bytes",
         result.markdown.len()
+    );
+}
+
+/// Regression (review should-fix): a genuine data table with one spanning row
+/// must keep all columns as a single GFM table, not fragment into a header-only
+/// table plus a relabeled `**x:** spans` line.
+#[test]
+fn test_html_data_table_spanning_row_keeps_columns() {
+    let input = br#"<html><body><table>
+        <tr><th>A</th><th>B</th><th>C</th></tr>
+        <tr><td>x</td><td colspan="2">spans</td></tr>
+    </table></body></html>"#;
+    let result = anytomd::convert_bytes(input, "html", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.contains("| A | B | C |"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("| x | spans |  |"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        !result.markdown.contains("**x:**"),
+        "row was relabeled: {}",
+        result.markdown
     );
 }

--- a/tests/test_html.rs
+++ b/tests/test_html.rs
@@ -98,3 +98,40 @@ fn test_html_convert_bytes_direct() {
     assert!(result.markdown.contains("# Hello"));
     assert!(result.markdown.contains("World"));
 }
+
+/// Integration test: a colspan/rowspan layout table converts via the hybrid path.
+///
+/// Mirrors the structure of a layout table (full-width banner, label/value rows,
+/// and a data grid) that previously collapsed to a single column. All columns
+/// must survive and the layout rows must linearize.
+#[test]
+fn test_html_colspan_layout_hybrid() {
+    let input = br#"<html><body><table>
+        <tr><td colspan="3"><h2>Section Title</h2></td></tr>
+        <tr><td>Field</td><td colspan="2">Value</td></tr>
+        <tr><td>Col A</td><td>Col B</td><td>Col C</td></tr>
+        <tr><td>1</td><td>2</td><td>3</td></tr>
+    </table></body></html>"#;
+    let result = anytomd::convert_bytes(input, "html", &ConversionOptions::default()).unwrap();
+
+    assert!(
+        result.markdown.contains("## Section Title"),
+        "banner not a heading: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("**Field:** Value"),
+        "label/value not linearized: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("| Col A | Col B | Col C |"),
+        "grid columns missing: {}",
+        result.markdown
+    );
+    assert!(
+        result.markdown.contains("| 1 | 2 | 3 |"),
+        "grid data missing: {}",
+        result.markdown
+    );
+}

--- a/tests/test_html.rs
+++ b/tests/test_html.rs
@@ -135,3 +135,40 @@ fn test_html_colspan_layout_hybrid() {
         result.markdown
     );
 }
+
+/// Regression (review finding): a nested table in a simple outer table must
+/// render as a standalone block, not be escaped into one cell; plain text must
+/// not leak GFM pipes.
+#[test]
+fn test_html_nested_table_not_mangled_end_to_end() {
+    let input =
+        br#"<html><body><table><tr><td>a<table><tr><td>x</td><td>y</td></tr></table></td><td>b</td></tr></table></body></html>"#;
+    let result = anytomd::convert_bytes(input, "html", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.contains("| x | y |"),
+        "md: {}",
+        result.markdown
+    );
+    assert!(
+        !result.markdown.contains("\\|"),
+        "escaped pipes: {}",
+        result.markdown
+    );
+    assert!(
+        !result.plain_text.contains('|'),
+        "plain leaked pipes: {:?}",
+        result.plain_text
+    );
+}
+
+/// Regression (review finding): a huge colspan must not drive unbounded output.
+#[test]
+fn test_html_colspan_dos_bounded_end_to_end() {
+    let input = br#"<html><body><table><tr><td colspan="1000000">X</td><td>Y</td></tr><tr><td colspan="1000000">P</td><td>Q</td></tr></table></body></html>"#;
+    let result = anytomd::convert_bytes(input, "html", &ConversionOptions::default()).unwrap();
+    assert!(
+        result.markdown.len() < 100_000,
+        "not bounded: {} bytes",
+        result.markdown.len()
+    );
+}

--- a/tests/test_pptx.rs
+++ b/tests/test_pptx.rs
@@ -12,7 +12,7 @@ use std::io::Cursor;
 /// Contains:
 /// - Slide 1: Title "Sample Presentation", body "Welcome to the presentation."
 /// - Slide 2: Text "Data Overview", table (Name/Value/Status with 3 data rows),
-///            speaker notes "Remember to explain the data table."
+///   speaker notes "Remember to explain the data table."
 /// - Slide 3: Title "Multilingual", Korean text, emoji, speaker notes
 #[test]
 fn test_pptx_convert_file_sample() {
@@ -290,6 +290,82 @@ fn test_pptx_group_shape_convert_file() {
 
     // Title from first slide
     assert_eq!(result.title, Some("Group Shape Demo".to_string()),);
+}
+
+/// Build a single-slide PPTX whose table uses a horizontal merge.
+fn build_merged_table_pptx() -> Vec<u8> {
+    use std::io::Write;
+    use zip::ZipWriter;
+    use zip::write::SimpleFileOptions;
+
+    let buf = Vec::new();
+    let mut zip = ZipWriter::new(Cursor::new(buf));
+    let opts = SimpleFileOptions::default();
+
+    zip.start_file("[Content_Types].xml", opts).unwrap();
+    zip.write_all(
+        br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#,
+    ).unwrap();
+
+    let pres_xml = r#"<?xml version="1.0"?><p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="rId1"/></p:sldIdLst></p:presentation>"#;
+    zip.start_file("ppt/presentation.xml", opts).unwrap();
+    zip.write_all(pres_xml.as_bytes()).unwrap();
+
+    let pres_rels = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#;
+    zip.start_file("ppt/_rels/presentation.xml.rels", opts)
+        .unwrap();
+    zip.write_all(pres_rels.as_bytes()).unwrap();
+
+    // Header row uses a 2-column horizontal merge (gridSpan + hMerge placeholder);
+    // the data row has two ordinary cells.
+    let slide1 = concat!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>"#,
+        r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main""#,
+        r#" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">"#,
+        r#"<p:cSld><p:spTree>"#,
+        r#"<p:sp><p:nvSpPr><p:cNvPr id="1" name="Title"/><p:cNvSpPr/><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr>"#,
+        r#"<p:txBody><a:p><a:r><a:t>Merged Table</a:t></a:r></a:p></p:txBody></p:sp>"#,
+        r#"<p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="3" name="Tbl"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr>"#,
+        r#"<a:graphic><a:graphicData><a:tbl>"#,
+        r#"<a:tr><a:tc gridSpan="2"><a:txBody><a:p><a:r><a:t>Wide Header</a:t></a:r></a:p></a:txBody></a:tc>"#,
+        r#"<a:tc hMerge="1"><a:txBody><a:p><a:r><a:t>Wide Header</a:t></a:r></a:p></a:txBody></a:tc></a:tr>"#,
+        r#"<a:tr><a:tc><a:txBody><a:p><a:r><a:t>L</a:t></a:r></a:p></a:txBody></a:tc>"#,
+        r#"<a:tc><a:txBody><a:p><a:r><a:t>R</a:t></a:r></a:p></a:txBody></a:tc></a:tr>"#,
+        r#"</a:tbl></a:graphicData></a:graphic></p:graphicFrame>"#,
+        r#"</p:spTree></p:cSld></p:sld>"#,
+    );
+    zip.start_file("ppt/slides/slide1.xml", opts).unwrap();
+    zip.write_all(slide1.as_bytes()).unwrap();
+
+    zip.finish().unwrap().into_inner()
+}
+
+/// Integration test: a PPTX table with a horizontal merge keeps all columns and
+/// does not duplicate the spanning cell's text into the merged placeholder.
+#[test]
+fn test_pptx_merged_table_columns() {
+    let data = build_merged_table_pptx();
+    let result = anytomd::convert_bytes(&data, "pptx", &ConversionOptions::default()).unwrap();
+
+    // Header row: spanning text in the first column, empty placeholder in the second.
+    assert!(
+        result.markdown.contains("| Wide Header |  |"),
+        "merged header columns wrong: {}",
+        result.markdown
+    );
+    // Data row keeps both columns.
+    assert!(
+        result.markdown.contains("| L | R |"),
+        "data columns missing: {}",
+        result.markdown
+    );
+    // The spanning text must appear exactly once (not duplicated into the placeholder).
+    assert_eq!(
+        result.markdown.matches("Wide Header").count(),
+        1,
+        "spanning text duplicated: {}",
+        result.markdown
+    );
 }
 
 /// End-to-end PPTX comment extraction through the public `convert_bytes` API.


### PR DESCRIPTION
## Problem

Tables that use **merged cells** or are used for **page layout** converted with
only the **first column preserved** — every other column was silently dropped.

Root cause: the table renderer derived the column count from row 0 and
pad/truncated every row to that width, while `gridSpan`/`vMerge` (DOCX),
`colspan`/`rowspan` (HTML), and the `tblGrid` column count were never parsed.
When row 0 was a single full-width banner cell (common in layout tables), the
column count became 1 and the whole table collapsed to one column — losing the
bulk of the document's content.

The same class of bug existed in the HTML converter (no `colspan`/`rowspan`
handling), and PPTX ignored DrawingML merge attributes.

## Approach

Every table — plain, merged, or layout — renders as **one empty-filled GFM
table of its true column width**. (An earlier hybrid banner/label-value
linearization was replaced after review discussion: its heuristics could not
reliably distinguish a layout label/value row from a genuine data row with a
span, so it mangled real data tables. One uniform grid is consistent and
lossless, which matters more for downstream LLM consumers.)

- A horizontally spanned cell (`gridSpan`/`colspan`) puts its text in the first
  covered column and leaves the spanned-over columns empty (empty-fill).
- A vertically merged continuation cell (`vMerge`/`rowspan`) renders blank.
- A full-width banner row stays a normal grid row — it is **not** turned into a
  heading or a `**Label:** value` line.
- The first row is the GFM header (HTML: the first `<thead>` row when present;
  remaining `<thead>` rows become body rows, nothing dropped).
- The one exception: a table containing a **nested table** is linearized — each
  cell's text and nested tables are emitted as standalone blocks in order,
  since a nested table cannot live inside a single GFM cell.

**Uniform tables with no merges keep the exact previous GFM path**, so ordinary
data tables (and CSV/XLSX, which share `markdown::build_table`) do not regress.
PPTX tables stay GFM tables; merge-continuation placeholders render empty so
columns stay aligned and the spanning cell's text is not duplicated.

`plain_text` stays tab-separated for grid regions and fully linearizes (no
markdown markers) for nested-table linearization. Output is byte-stable.

## Key changes

### DOCX (`src/converter/docx.rs`)
- Replaced the single `in_table` boolean state machine with a **table stack**,
  so nested tables parse correctly and render in place.
- Parse `gridSpan`/`vMerge`/`gridCol` in both `Event::Start` and `Event::Empty`
  arms. `tblGrid` is a **floor**, not a ceiling: the grid width is
  max(`tblGrid` count, widest row's summed spans), so trailing cells are never
  silently truncated by a narrow declared grid.
- Orphan `vMerge` continuation cells (no matching restart) preserve their text.
- Content-empty nested tables are suppressed at the source so they cannot
  inject a degenerate `|  |` skeleton into markdown.

### HTML (`src/converter/html.rs`)
- Replaced the single table collector with a **stack** for nesting; parse
  `colspan`/`rowspan`, normalizing rowspans into explicit placeholder cells
  (ordered, deterministic — column-indexed carried spans, O(width) per row).
- Cells store ordered `CellSegment` (Text | Table) values, so text before and
  after a nested table keeps its position; sibling nested tables are separated
  by a blank line so GFM does not fuse them.
- The GFM header is the first `<thead>` row; all other rows render as body in
  source order.

### PPTX (`src/converter/pptx.rs`)
- Parse `hMerge`/`vMerge`/`gridSpan`/`rowSpan`; merge-continuation placeholder
  cells render empty so the spanning cell's text is not duplicated.

### Resource safety (all bounds observable via `ResourceLimitReached` warnings)
- Width capped at `MAX_TABLE_COLS` (4096); the rendered area (rows × width) and
  the blocks emitted by nested-table linearization are capped at
  `MAX_TABLE_CELLS` (100k) in both DOCX and HTML — a hostile
  `colspan="1000000"` or a rowspan×colspan product bomb cannot drive unbounded
  allocation or output.
- Every truncation path (rows, columns, linearized blocks) appends a structured
  warning — content is never silently dropped — and suppressed (content-empty)
  tables never emit phantom warnings.

## Testing

- Unit tests for grid-width computation, span expansion, merge handling, and
  every render path; integration tests with synthetic in-memory
  DOCX/HTML/PPTX fixtures; a DOCX golden fixture for a banner + label/value +
  vMerge data grid.
- Regression tests for every review finding across three review rounds
  (resource bounds and their observability, nested-table ordering and
  suppression, header selection, multi-row `<thead>`, orphan merges,
  data-table spanning rows).
- The prior `test_docx_table_merged_cells_no_panic`, which asserted the
  truncation bug as expected behavior, now asserts full column preservation.

Full local verification passes: `cargo test`, `cargo clippy -- -D warnings`
(default, `async`, `async-gemini`), `cargo fmt --check`, `cargo build
--release`, `cargo doc --no-deps` (zero warnings), and the WASM target checks.
